### PR TITLE
Fix(eagle3): Derive aux hidden count from drafter config

### DIFF
--- a/tests/integration/test_eagle3_aux_hidden_contract.py
+++ b/tests/integration/test_eagle3_aux_hidden_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _minimal_eagle3_config(**overrides) -> dict:
+    config = {
+        "architectures": ["LlamaForCausalLMEagle3"],
+        "attention_bias": False,
+        "hidden_act": "silu",
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "max_position_embeddings": 128,
+        "model_type": "llama",
+        "num_attention_heads": 2,
+        "num_hidden_layers": 1,
+        "num_key_value_heads": 2,
+        "pad_token_id": 0,
+        "pretraining_tp": 1,
+        "rms_norm_eps": 1e-6,
+        "rope_scaling": None,
+        "tie_word_embeddings": False,
+        "target_hidden_size": 4,
+        "vocab_size": 32,
+    }
+    config.update(overrides)
+    return config
+
+
+def test_qwen3_eagle3_config_alias_preserves_five_target_layers(tmp_path) -> None:
+    pytest.importorskip("transformers")
+    from verl_speco.models.auto import AutoDraftModelConfig
+
+    config_path = tmp_path / "config.json"
+    config = _minimal_eagle3_config(
+        architectures=["Qwen3Eagle3Model"],
+        target_layer_ids=[1, 9, 17, 25, 33],
+    )
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    loaded = AutoDraftModelConfig.from_file(str(config_path))
+
+    assert loaded.architectures == ["LlamaForCausalLMEagle3"]
+    assert loaded.target_layer_ids == [1, 9, 17, 25, 33]
+    assert loaded.eagle_aux_hidden_state_layer_ids == [1, 9, 17, 25, 33]
+    assert loaded.eagle_config["eagle_aux_hidden_state_layer_ids"] == [1, 9, 17, 25, 33]
+    assert loaded.num_aux_hidden_states == 5
+
+
+def test_eagle3_model_uses_dynamic_aux_hidden_count() -> None:
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    from verl_speco.models.auto import AutoDraftModelConfig
+    from verl_speco.models.eagle.llama_eagle import LlamaForCausalLMEagle3
+
+    config = AutoDraftModelConfig._config_mapping["LlamaForCausalLMEagle3"].from_dict(
+        _minimal_eagle3_config(
+            target_hidden_size=4,
+            target_layer_ids=[1, 9, 17, 25, 33],
+            num_aux_hidden_states=5,
+        )
+    )
+    model = LlamaForCausalLMEagle3(config)
+
+    assert model.num_aux_hidden_states == 5
+    assert model.fc.in_features == 20
+    projected = model.project_hidden_states(torch.randn(2, 3, 20))
+    assert projected.shape == (2, 3, config.hidden_size)
+
+    with pytest.raises(ValueError, match="num_aux_hidden_states=5"):
+        model.project_hidden_states(torch.randn(2, 3, 12))

--- a/tests/integration/test_oldlogprob_runtime_contract.py
+++ b/tests/integration/test_oldlogprob_runtime_contract.py
@@ -64,7 +64,7 @@ def test_eagle3_oldlogprob_falls_back_to_default_three_layers() -> None:
     assert eagle3_num_aux_hidden_states_from_config({"speculative_algorithm": "EAGLE3"}) is None
 
 
-def test_eagle3_oldlogprob_ignores_dflash_target_layer_ids_alias() -> None:
+def test_eagle3_oldlogprob_accepts_top_level_target_layer_ids() -> None:
     drafter_cfg = {
         "speculative_algorithm": "EAGLE3",
         "target_layer_ids": [1, 9, 17, 25, 33],
@@ -74,8 +74,8 @@ def test_eagle3_oldlogprob_ignores_dflash_target_layer_ids_alias() -> None:
         drafter_cfg,
         target_num_hidden_layers=36,
         model_configs=[],
-    ) == [2, 18, 33]
-    assert eagle3_num_aux_hidden_states_from_config(drafter_cfg) is None
+    ) == [1, 9, 17, 25, 33]
+    assert eagle3_num_aux_hidden_states_from_config(drafter_cfg) == 5
 
 
 def _selection_context(*, batch_size: int, hidden_rows: int) -> dict:

--- a/verl_speco/backends/eagle3_trainer_backend.py
+++ b/verl_speco/backends/eagle3_trainer_backend.py
@@ -8,6 +8,7 @@ from torch.nn import functional as F
 from transformers import AutoConfig
 
 from verl_speco.models.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from verl_speco.models.eagle.llama_eagle import resolve_eagle3_num_aux_hidden_states
 from verl_speco.trainer.checkpoint import log_drafter_checkpoint_step
 from verl_speco.models.target.target_head import TargetHead
 from verl.utils.fsdp_utils import get_device_id
@@ -642,7 +643,11 @@ class Eagle3TrainerBackend:
         # Initialize model
         if spec_model_path and os.path.exists(spec_model_path):
             log_drafter_checkpoint_step(logger, spec_model_path, action="Loading EAGLE3 drafter weights")
-            loaded = factory_cls.from_pretrained(spec_model_path, output_loading_info=True)
+            loaded = factory_cls.from_pretrained(
+                spec_model_path,
+                config=drafter_config,
+                output_loading_info=True,
+            )
             if isinstance(loaded, tuple):
                 drafter_module, loading_info = loaded
                 missing_keys = set(loading_info.get("missing_keys", []))
@@ -763,18 +768,7 @@ class Eagle3TrainerBackend:
         }
         pad_id = int(getattr(model_config, "pad_token_id", 0) or 0)
         h_dim = getattr(model_config, "target_hidden_size", model_config.hidden_size)
-        num_aux_hidden_states = getattr(model_config, "num_aux_hidden_states", None)
-        if num_aux_hidden_states is None:
-            eagle_config = getattr(model_config, "eagle_config", None)
-            layer_ids = getattr(eagle_config, "target_hidden_layer_ids", None)
-            if layer_ids is None:
-                layer_ids = getattr(eagle_config, "eagle_aux_hidden_state_layer_ids", None)
-            if layer_ids is None and isinstance(eagle_config, dict):
-                layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids") or eagle_config.get(
-                    "target_hidden_layer_ids"
-                )
-            num_aux_hidden_states = len(layer_ids) if layer_ids else 3
-        num_aux_hidden_states = int(num_aux_hidden_states)
+        num_aux_hidden_states = resolve_eagle3_num_aux_hidden_states(model_config)
         aux_hidden_size = num_aux_hidden_states * h_dim
         use_logits = bool(self.config.rollout.drafter.training.get("use_logits", False))
 

--- a/verl_speco/integration/oldlogprob_layer_ids.py
+++ b/verl_speco/integration/oldlogprob_layer_ids.py
@@ -57,6 +57,7 @@ def _generic_aux_layer_ids_from_config(config: Any) -> list[int] | None:
         ("eagle_config", "eagle_aux_hidden_state_layer_ids"),
         ("target_hidden_layer_ids",),
         ("eagle_aux_hidden_state_layer_ids",),
+        ("target_layer_ids",),
     )
     for path in candidates:
         layer_ids = _normalize_layer_ids(_get_nested(config, path, None))

--- a/verl_speco/models/auto.py
+++ b/verl_speco/models/auto.py
@@ -13,6 +13,76 @@ from .dflash import DFlashConfig, DFlashDraftModel
 from .eagle.llama_eagle import LlamaForCausalLMEagle3
 
 
+_EAGLE3_ARCHITECTURE_ALIASES = {
+    "LlamaForCausalLMEagle3",
+    "Qwen3Eagle3Model",
+}
+
+
+def _normalize_int_list(value):
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return [int(value)]
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        if raw.startswith("["):
+            value = json.loads(raw)
+        else:
+            value = [part.strip() for part in raw.split(",") if part.strip()]
+    return [int(item) for item in list(value)]
+
+
+def _first_present_eagle3_layer_ids(config: dict):
+    eagle_config = config.get("eagle_config")
+    candidates = []
+    if isinstance(eagle_config, dict):
+        candidates.extend(
+            [
+                eagle_config.get("target_hidden_layer_ids"),
+                eagle_config.get("eagle_aux_hidden_state_layer_ids"),
+            ]
+        )
+    candidates.extend(
+        [
+            config.get("target_hidden_layer_ids"),
+            config.get("eagle_aux_hidden_state_layer_ids"),
+            config.get("target_layer_ids"),
+        ]
+    )
+    for candidate in candidates:
+        layer_ids = _normalize_int_list(candidate)
+        if layer_ids is not None:
+            return layer_ids
+    return None
+
+
+def _normalize_eagle3_config_dict(config: dict) -> dict:
+    layer_ids = _first_present_eagle3_layer_ids(config)
+    if layer_ids is not None:
+        configured_count = config.get("num_aux_hidden_states")
+        if configured_count is not None and int(configured_count) != len(layer_ids):
+            raise ValueError(
+                "EAGLE3 num_aux_hidden_states does not match layer ids: "
+                f"{configured_count} != {len(layer_ids)}"
+            )
+        config["num_aux_hidden_states"] = len(layer_ids)
+        config["eagle_aux_hidden_state_layer_ids"] = layer_ids
+        eagle_config = config.get("eagle_config")
+        if not isinstance(eagle_config, dict):
+            eagle_config = {}
+            config["eagle_config"] = eagle_config
+        eagle_config.setdefault("eagle_aux_hidden_state_layer_ids", layer_ids)
+        eagle_config.setdefault("target_hidden_layer_ids", layer_ids)
+    elif "num_aux_hidden_states" in config:
+        config["num_aux_hidden_states"] = int(config["num_aux_hidden_states"])
+
+    config["architectures"] = ["LlamaForCausalLMEagle3"]
+    return config
+
+
 class AutoDraftModel(AutoModelForCausalLMBase):
 
     @classmethod
@@ -71,6 +141,7 @@ class AutoEagle3DraftModel(AutoDraftModel):
 class AutoDraftModelConfig:
     _config_mapping = {
         "LlamaForCausalLMEagle3": LlamaConfig,
+        "Qwen3Eagle3Model": LlamaConfig,
         "DFlashDraftModel": DFlashConfig,
     }
 
@@ -110,5 +181,7 @@ class AutoDraftModelConfig:
         if architecture == "DFlashDraftModel":
             config["model_type"] = DFlashConfig.model_type
             config["architectures"] = ["DFlashDraftModel"]
+        elif architecture in _EAGLE3_ARCHITECTURE_ALIASES:
+            config = _normalize_eagle3_config_dict(config)
 
         return cls._config_mapping[architecture].from_dict(config)

--- a/verl_speco/models/eagle/llama_eagle.py
+++ b/verl_speco/models/eagle/llama_eagle.py
@@ -33,6 +33,60 @@ except ImportError:
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
+
+def _get_config_value(config, key: str, default=None):
+    if config is None:
+        return default
+    if hasattr(config, "get"):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _normalize_layer_ids(layer_ids) -> list[int] | None:
+    if layer_ids is None:
+        return None
+    if isinstance(layer_ids, int):
+        return [int(layer_ids)]
+    if isinstance(layer_ids, str):
+        raw = layer_ids.strip()
+        if not raw:
+            return None
+        if raw.startswith("["):
+            import json
+
+            layer_ids = json.loads(raw)
+        else:
+            layer_ids = [part.strip() for part in raw.split(",") if part.strip()]
+    return [int(layer_id) for layer_id in list(layer_ids)]
+
+
+def _eagle3_aux_layer_ids_from_config(config) -> list[int] | None:
+    eagle_config = _get_config_value(config, "eagle_config", None)
+    candidates = (
+        _get_config_value(eagle_config, "target_hidden_layer_ids", None),
+        _get_config_value(eagle_config, "eagle_aux_hidden_state_layer_ids", None),
+        _get_config_value(config, "target_hidden_layer_ids", None),
+        _get_config_value(config, "eagle_aux_hidden_state_layer_ids", None),
+        _get_config_value(config, "target_layer_ids", None),
+    )
+    for layer_ids in candidates:
+        normalized = _normalize_layer_ids(layer_ids)
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def resolve_eagle3_num_aux_hidden_states(config) -> int:
+    num_aux_hidden_states = _get_config_value(config, "num_aux_hidden_states", None)
+    if num_aux_hidden_states is None:
+        layer_ids = _eagle3_aux_layer_ids_from_config(config)
+        num_aux_hidden_states = len(layer_ids) if layer_ids else 3
+    num_aux_hidden_states = int(num_aux_hidden_states)
+    if num_aux_hidden_states <= 0:
+        raise ValueError(f"EAGLE3 num_aux_hidden_states must be positive, got {num_aux_hidden_states}")
+    return num_aux_hidden_states
+
+
 # Copied from transformers.models.bart.modeling_bart._make_causal_mask
 def _make_causal_mask(
     input_ids_shape: torch.Size,
@@ -1370,14 +1424,24 @@ class LlamaForCausalLMEagle3(Eagle3DraftModel):
         self.vocab_size = config.vocab_size
         self.draft_vocab_size = getattr(config, "draft_vocab_size", config.vocab_size)
         self.target_hidden_size = getattr(config, "target_hidden_size", config.hidden_size)
+        self.num_aux_hidden_states = resolve_eagle3_num_aux_hidden_states(config)
         self.embed_tokens = nn.Embedding(
             config.vocab_size, config.hidden_size, config.pad_token_id
         )
         self.midlayer = LlamaDecoderLayer(config, attention_backend=attention_backend)
 
         self.fc = torch.nn.Linear(
-            self.target_hidden_size * 3, config.hidden_size, bias=False
+            self.target_hidden_size * self.num_aux_hidden_states, config.hidden_size, bias=False
         )
+        if getattr(config, "fc_norm", False):
+            self.fc_norm = nn.ModuleList(
+                [
+                    LlamaRMSNorm(self.target_hidden_size, eps=config.rms_norm_eps)
+                    for _ in range(self.num_aux_hidden_states)
+                ]
+            )
+        else:
+            self.fc_norm = None
 
         self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.lm_head = nn.Linear(
@@ -1415,7 +1479,8 @@ class LlamaForCausalLMEagle3(Eagle3DraftModel):
     ):
         """
         Arguments:
-            hidden_states (`torch.FloatTensor`): input to the layer, cat low, mid high hidden_states of shape `(batch, seq_len, hidden_states * 3)`
+            hidden_states (`torch.FloatTensor`): concatenated target aux hidden states of shape
+                `(batch, seq_len, target_hidden_size * num_aux_hidden_states)`
             input_ids (`torch.LongTensor`): input ids of shape `(batch, seq_len)`
             attention_mask (`torch.FloatTensor`): attention mask of size
                 `(batch, 1, tgt_len, src_len)` where padding elements are indicated by very large negative values.
@@ -1509,13 +1574,17 @@ class LlamaForCausalLMEagle3(Eagle3DraftModel):
         return self.embed_tokens(input_ids)
 
     def project_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        # eagle 3 requires hidden states from 3 layers
-        expected_hidden_size = self.target_hidden_size * 3
+        expected_hidden_size = self.target_hidden_size * self.num_aux_hidden_states
         if hidden_states.size(-1) != expected_hidden_size:
             raise ValueError(
                 f"EAGLE3 expects hidden_states last dim {expected_hidden_size}, "
-                f"got {hidden_states.size(-1)}"
+                f"got {hidden_states.size(-1)} "
+                f"(target_hidden_size={self.target_hidden_size}, "
+                f"num_aux_hidden_states={self.num_aux_hidden_states})"
             )
+        if self.fc_norm is not None:
+            chunks = hidden_states.chunk(self.num_aux_hidden_states, dim=-1)
+            hidden_states = torch.cat([norm(chunk) for norm, chunk in zip(self.fc_norm, chunks)], dim=-1)
         return self.fc(hidden_states)
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/verl_speco/trainer/speco_ray_trainer.py
+++ b/verl_speco/trainer/speco_ray_trainer.py
@@ -659,6 +659,7 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             ("eagle_config", "eagle_aux_hidden_state_layer_ids"),
             ("target_hidden_layer_ids",),
             ("eagle_aux_hidden_state_layer_ids",),
+            ("target_layer_ids",),
         )
         for path in candidates:
             layer_ids = _get_nested(config, path, None)


### PR DESCRIPTION
## Summary

- Derive EAGLE3 `num_aux_hidden_states` from the drafter config instead of assuming 3 aux hidden layers.
- Normalize `Qwen3Eagle3Model` drafter configs so top-level `target_layer_ids` populate EAGLE3 aux-layer metadata.
- Apply the same aux-hidden count when preprocessing drafter training samples and when resolving old-logprob hidden collection layer IDs.
- Add contract tests for 5-layer EAGLE3 configs while preserving the default 3-layer behavior.

## Motivation

Some EAGLE3 drafter checkpoints, such as Qwen3-style configs, provide 5 target hidden layers via `target_layer_ids`. The previous training path still assumed 3 aux hidden states in the model projection and old-logprob/training-data handling, which could reject or mis-handle those checkpoints.

This change keeps the legacy 3-layer fallback, but lets checkpoints with explicit layer IDs drive the expected hidden-state count.
