### PR TITLE
Fix(trainer): Respect old-logprob entropy config without drafter

### DIFF
--- a/tests/integration/test_drafter_runtime_control_contract.py
+++ b/tests/integration/test_drafter_runtime_control_contract.py
@@ -17,6 +17,7 @@ def _trainer(training_cfg: dict, *, step: int = 1) -> SpecoRayPPOTrainer:
     trainer.global_steps = step
     trainer.config = SimpleNamespace(
         actor_rollout_ref=SimpleNamespace(
+            actor=SimpleNamespace(calculate_entropy=False),
             rollout=SimpleNamespace(
                 drafter=SimpleNamespace(
                     enable=True,
@@ -29,6 +30,26 @@ def _trainer(training_cfg: dict, *, step: int = 1) -> SpecoRayPPOTrainer:
     trainer._pending_drafter_publish_refs = None
     trainer._speco_last_collected_samples = 0
     trainer._ray_get_if_needed = lambda value: value
+    return trainer
+
+
+def _no_drafter_trainer(*, calculate_entropy=Ellipsis) -> SpecoRayPPOTrainer:
+    trainer = SpecoRayPPOTrainer.__new__(SpecoRayPPOTrainer)
+    actor = SimpleNamespace()
+    if calculate_entropy is not Ellipsis:
+        actor.calculate_entropy = calculate_entropy
+    trainer.config = SimpleNamespace(
+        actor_rollout_ref=SimpleNamespace(
+            actor=actor,
+            rollout=SimpleNamespace(
+                drafter=SimpleNamespace(
+                    enable=False,
+                    enable_drafter_training=False,
+                    training={},
+                )
+            ),
+        )
+    )
     return trainer
 
 
@@ -65,6 +86,12 @@ def test_drafter_training_attempt_requires_interval_and_samples() -> None:
 
     trainer._speco_last_collected_samples = 1
     assert trainer._speco_should_attempt_drafter_train_this_step() is True
+
+
+def test_oldlogprob_entropy_wrapper_respects_no_drafter_entropy_config() -> None:
+    assert _no_drafter_trainer(calculate_entropy=False)._speco_oldlogprob_entropy_hook_enabled() is True
+    assert _no_drafter_trainer(calculate_entropy=True)._speco_oldlogprob_entropy_hook_enabled() is False
+    assert _no_drafter_trainer()._speco_oldlogprob_entropy_hook_enabled() is False
 
 
 def test_async_publish_sets_pending_ref_and_waits_before_next_publish() -> None:

--- a/tests/integration/test_oldlogprob_runtime_contract.py
+++ b/tests/integration/test_oldlogprob_runtime_contract.py
@@ -27,6 +27,16 @@ def test_oldlogprob_collection_is_disabled_by_default() -> None:
     assert oldlogprob_hidden_runtime_enabled({"rollout": {"drafter": _drafter(False)}}) is False
 
 
+def test_oldlogprob_collection_requires_online_drafter_training() -> None:
+    rollout_disabled = _drafter(True)
+    rollout_disabled["enable"] = False
+    training_disabled = _drafter(True)
+    training_disabled["enable_drafter_training"] = False
+
+    assert oldlogprob_hidden_runtime_enabled({"rollout": {"drafter": rollout_disabled}}) is False
+    assert oldlogprob_hidden_runtime_enabled({"rollout": {"drafter": training_disabled}}) is False
+
+
 def test_oldlogprob_collection_accepts_both_config_shapes() -> None:
     assert oldlogprob_hidden_runtime_enabled({"rollout": {"drafter": _drafter(True)}})
     assert oldlogprob_hidden_runtime_enabled(

--- a/verl_speco/integration/oldlogprob_runtime.py
+++ b/verl_speco/integration/oldlogprob_runtime.py
@@ -73,6 +73,10 @@ def _load_drafter_env(raw: str | None = None) -> dict[str, Any]:
 
 
 def _oldlogprob_enabled_from_drafter(drafter: Any) -> bool:
+    if not bool(_get_nested(drafter, ("enable",), False)):
+        return False
+    if not bool(_get_nested(drafter, ("enable_drafter_training",), False)):
+        return False
     training = _get_nested(drafter, ("training",), {}) or {}
     return bool(_get_nested(training, ("collect_hidden_states_from_old_logprob",), False))
 

--- a/verl_speco/trainer/speco_ray_trainer.py
+++ b/verl_speco/trainer/speco_ray_trainer.py
@@ -615,17 +615,30 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             raise ValueError(f"Unsupported SPECO old-logprob hidden capture impl: {capture_impl!r}")
         return True
 
-    def _speco_oldlogprob_entropy_hook_enabled(self) -> bool:
-        return self.is_drafter_rollout_enabled(self.config) and not self._speco_oldlogprob_calculate_entropy()
-
-    def _speco_oldlogprob_calculate_entropy(self) -> bool:
+    def _speco_oldlogprob_entropy_config_value(self):
         training_cfg = self._speco_drafter_training_config()
         value = training_cfg.get("old_logprob_calculate_entropy", None)
         if value is None:
-            value = _get_nested(self.config, ("actor_rollout_ref", "actor", "calculate_entropy"), False)
+            value = _get_nested(self.config, ("actor_rollout_ref", "actor", "calculate_entropy"), None)
+        return value
+
+    @staticmethod
+    def _speco_bool_config(value: Any) -> bool:
         if isinstance(value, str):
             return value.strip().lower() in {"1", "true", "yes", "y", "on"}
         return bool(value)
+
+    def _speco_oldlogprob_entropy_hook_enabled(self) -> bool:
+        value = self._speco_oldlogprob_entropy_config_value()
+        if value is None and not self.is_drafter_rollout_enabled(self.config):
+            return False
+        return not self._speco_oldlogprob_calculate_entropy()
+
+    def _speco_oldlogprob_calculate_entropy(self) -> bool:
+        value = self._speco_oldlogprob_entropy_config_value()
+        if value is None:
+            value = False
+        return self._speco_bool_config(value)
 
     def _speco_oldlogprob_hidden_capture_impl(self) -> str:
         training_cfg = self._speco_drafter_training_config()


### PR DESCRIPTION
## Summary

This PR fixes a no-drafter NPU old-logprob failure and tightens SPECO old-logprob runtime gating.

When drafter training is disabled, upstream verl v0.8.0 uses the original `_compute_old_log_prob`, which forces `calculate_entropy=True` even when `actor_rollout_ref.actor.calculate_entropy=False`. On NPU this can trigger an async device error during actor logprob inference. When drafter training is enabled, SPECO already replaces this path and respects the entropy config, so the failure does not appear.

This PR makes SPECO respect the explicit old-logprob entropy config even without a drafter, while keeping baseline behavior unchanged when entropy is not explicitly configured.

## Changes

- Respect `actor_rollout_ref.actor.calculate_entropy=False` / `old_logprob_calculate_entropy=False` in no-drafter old-logprob computation.
- Reuse SPECO’s existing no-forced-entropy old-logprob wrapper outside drafter training when entropy is explicitly disabled.
- Require both `drafter.enable=True` and `drafter.enable_drafter_training=True` before enabling old-logprob hidden-state collection runtime.
- Add contract tests for:
  - no-drafter entropy wrapper behavior
  - hidden collection runtime requiring online drafter training

Co-authored-by: crp0128 <191679376@qq.com>
Co-authored-by: Mengyuyang <781650427@qq.com>