### PR TITLE
fix(ci): run NPU tests for fork pull requests

### DIFF
--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -85,7 +85,7 @@ env:
 jobs:
   example:
     name: NPU ${{ matrix.backend }} ${{ matrix.drafter }} example
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: [self-hosted, linux-aarch64-a2-8]
     timeout-minutes: 180
     environment: speco-npu-ci


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                    
  - Allow NPU example tests to run for pull requests originating from forked repositories.
  - Keep the existing NPU PR trigger, smoke-test matrix, runner configuration, and other CI     
  behavior unchanged.
  - Preserve the previous same-repository restriction as a comment so it can be restored if     
  needed.
  - Leave the GPU workflow unchanged.

  ## Why

  The NPU workflow already listens for pull requests targeting `main`, but its job-level        
  condition skips PRs whose head repository differs from the base repository. Disabling that    
  condition allows fork-originated contributions to receive the same NPU CI coverage.

  This does not duplicate an existing PR to the best of my knowledge.

  ## Testing

  - [x] Ran `git diff --check`
  - [x] Verified that only `.github/workflows/npu_unit_tests.yml` changed
  - [x] Verified that the GPU workflow remains unchanged
  - [ ] Confirm the NPU job is triggered by a pull request from a fork

  ## AI Assistance

  AI assistance was used to inspect the workflow configuration, identify the fork-specific      
  condition, and prepare this change. I reviewed and understand the changed line.