### PR TITLE
fix(trainer): stop scaling drafter gradients down by world size

### DIFF
--- a/tests/unit/test_drafter_loss_reduction.py
+++ b/tests/unit/test_drafter_loss_reduction.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+base_trainer_mod = pytest.importorskip("verl_speco.trainer.base_trainer")
+
+DrafterBaseTrainer = base_trainer_mod.DrafterBaseTrainer
+
+
+def _bare_trainer(sp_size=1, dp_size=1, sp_group=None, dp_group=None):
+    trainer = object.__new__(DrafterBaseTrainer)
+    trainer.training_device_mesh = None
+    trainer._get_sp_group = lambda: sp_group
+    trainer._get_dp_group = lambda: dp_group
+    trainer._get_sp_world_size = lambda: sp_size
+    trainer._get_dp_world_size = lambda: dp_size
+    return trainer
+
+
+def test_reduce_loss_metrics_single_rank_passthrough():
+    trainer = _bare_trainer()
+    l_v = torch.tensor(2.0, requires_grad=True) * 1.0
+    l_p = torch.tensor(3.0, requires_grad=True) * 1.0
+    l_n = torch.tensor(4.0)
+
+    global_vloss, global_ploss, global_tokens, world_size = trainer._reduce_loss_metrics(l_v, l_p, l_n)
+
+    assert world_size == 1
+    assert not global_vloss.requires_grad
+    assert not global_ploss.requires_grad
+    assert torch.equal(global_vloss, torch.tensor(2.0))
+    assert torch.equal(global_ploss, torch.tensor(3.0))
+    assert torch.equal(global_tokens, torch.tensor(4.0))
+
+
+def test_reduce_loss_metrics_world_size_is_sp_times_dp(monkeypatch):
+    calls = []
+    monkeypatch.setattr(base_trainer_mod.dist, "all_reduce", lambda tensor, group=None: calls.append(group))
+
+    trainer = _bare_trainer(sp_size=4, dp_size=2, sp_group="sp", dp_group="dp")
+    zeros = torch.zeros(())
+    _, _, _, world_size = trainer._reduce_loss_metrics(zeros, zeros, zeros)
+
+    assert world_size == 8
+    assert calls == ["sp", "dp"]
+
+
+def test_dp_local_loss_scaling_recovers_global_token_mean_gradient(monkeypatch):
+    """Emulate 2 DP ranks: per-rank scaled local losses, backward, then an
+    FSDP-style gradient mean must equal the global token-mean gradient."""
+    torch.manual_seed(0)
+    rank_inputs = [torch.randn(3, 4), torch.randn(5, 4)]
+    total_tokens = sum(x.shape[0] for x in rank_inputs)
+
+    def token_sum_loss(weight, inputs):
+        return ((inputs @ weight) ** 2).sum()
+
+    weight_ref = torch.randn(4, requires_grad=True)
+    reference = (token_sum_loss(weight_ref, rank_inputs[0]) + token_sum_loss(weight_ref, rank_inputs[1])) / float(
+        total_tokens
+    )
+    reference.backward()
+
+    per_rank_grads = []
+    for rank in (0, 1):
+        weight = weight_ref.detach().clone().requires_grad_(True)
+        l_v = torch.zeros(())
+        l_p = token_sum_loss(weight, rank_inputs[rank])
+        l_n = torch.tensor(float(rank_inputs[rank].shape[0]))
+
+        other = 1 - rank
+        other_metrics = torch.stack(
+            [
+                torch.zeros(()),
+                token_sum_loss(weight_ref.detach(), rank_inputs[other]).detach(),
+                torch.tensor(float(rank_inputs[other].shape[0])),
+            ]
+        )
+
+        def fake_all_reduce(tensor, group=None, _other=other_metrics):
+            tensor += _other
+
+        monkeypatch.setattr(base_trainer_mod.dist, "all_reduce", fake_all_reduce)
+        trainer = _bare_trainer(dp_size=2, dp_group="dp")
+
+        _, global_ploss, global_tokens, world_size = trainer._reduce_loss_metrics(l_v, l_p, l_n)
+        assert world_size == 2
+        assert torch.allclose(global_tokens, torch.tensor(float(total_tokens)))
+
+        denom = global_tokens.clamp(min=1.0)
+        local_loss = (0.0 * l_v + 1.0 * l_p) * (float(world_size) / denom)
+        local_loss.backward()
+        per_rank_grads.append(weight.grad)
+
+    fsdp_mean_grad = (per_rank_grads[0] + per_rank_grads[1]) / 2.0
+    assert torch.allclose(fsdp_mean_grad, weight_ref.grad, atol=1e-6)

--- a/verl_speco/trainer/base_trainer.py
+++ b/verl_speco/trainer/base_trainer.py
@@ -3288,6 +3288,34 @@ class DrafterBaseTrainer:
         
         return await self._training_step_on_batch(batch, step)
 
+    def _reduce_loss_metrics(
+        self, l_v: torch.Tensor, l_p: torch.Tensor, l_n: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        """All-reduce detached loss/token sums across the SP/DP groups.
+
+        Returns the global sums plus the number of ranks that participated in
+        the reduction. The all-reduce is detached, so the caller must scale its
+        local loss by that world size to cancel FSDP's gradient averaging over
+        the same ranks.
+        """
+        metrics = torch.stack([l_v.detach(), l_p.detach(), l_n.detach()])
+        reduce_world_size = 1
+        sp_group = self._get_sp_group()
+        dp_group = self._get_dp_group()
+        if sp_group is not None and self._get_sp_world_size() > 1:
+            dist.all_reduce(metrics, group=sp_group)
+            reduce_world_size *= self._get_sp_world_size()
+            if dp_group is not None and self._get_dp_world_size() > 1:
+                dist.all_reduce(metrics, group=dp_group)
+                reduce_world_size *= self._get_dp_world_size()
+        elif dp_group is not None and self._get_dp_world_size() > 1:
+            dist.all_reduce(metrics, group=dp_group)
+            reduce_world_size *= self._get_dp_world_size()
+        elif self.training_device_mesh is not None and self.training_device_mesh.size() > 1:
+            dist.all_reduce(metrics, group=self.training_device_mesh.get_group())
+            reduce_world_size *= self.training_device_mesh.size()
+        return metrics[0], metrics[1], metrics[2], reduce_world_size
+
     async def _training_step_on_batch(self, batch: dict[str, torch.Tensor], step: int) -> bool:
         self.model.train()
         self.optimizer.zero_grad(set_to_none=True)
@@ -3308,27 +3336,9 @@ class DrafterBaseTrainer:
 
         # Reduce scalar loss statistics once across SP/DP groups.
         reduce_ts = time.time()
-        sp_group = self._get_sp_group()
-        dp_group = self._get_dp_group()
-        if sp_group is not None and self._get_sp_world_size() > 1:
-            metrics = torch.stack([l_v, l_p, l_n])
-            dist.all_reduce(metrics, group=sp_group)
-            if dp_group is not None and self._get_dp_world_size() > 1:
-                dist.all_reduce(metrics, group=dp_group)
-            global_vloss, global_ploss, global_tokens = metrics[0], metrics[1], metrics[2]
-        elif dp_group is not None and self._get_dp_world_size() > 1:
-            metrics = torch.stack([l_v, l_p, l_n])
-            dist.all_reduce(metrics, group=dp_group)
-            global_vloss, global_ploss, global_tokens = metrics[0], metrics[1], metrics[2]
-        elif self.training_device_mesh is not None and self.training_device_mesh.size() > 1:
-            metrics = torch.stack([l_v, l_p, l_n])
-            dist.all_reduce(metrics, group=self.training_device_mesh.get_group())
-            global_vloss, global_ploss, global_tokens = metrics[0], metrics[1], metrics[2]
-        else:
-            global_vloss, global_ploss, global_tokens = l_v, l_p, l_n
+        global_vloss, global_ploss, global_tokens, reduce_world_size = self._reduce_loss_metrics(l_v, l_p, l_n)
         self.record_training_timing("timing_s/drafter_reduce_loss", time.time() - reduce_ts)
-        
-        # 最终 Loss 平滑处理
+
         if float(global_tokens.detach().float().item()) <= 0:
             logger.debug(
                 f"Step {self.training_steps + 1}: no finite drafter target tokens, skipping optimizer step"
@@ -3339,7 +3349,7 @@ class DrafterBaseTrainer:
         vloss = global_vloss / denom
         ploss = global_ploss / denom
 
-        # 使用 backend 传回的权重合成最终 Loss
+        # Global token-mean loss, identical on every rank; used for guards and logging.
         loss = loss_dict["v_weight"] * vloss + loss_dict["p_weight"] * ploss
         if not torch.isfinite(loss):
             logger.error(
@@ -3351,9 +3361,17 @@ class DrafterBaseTrainer:
             )
             return False
 
-        # 反向传播
+        # Backward on this rank's local loss sums: the metric all-reduce above is
+        # outside the autograd graph, so each rank's backward carries only its own
+        # contribution, and FSDP then averages gradients across the same
+        # `reduce_world_size` ranks. Scaling by `reduce_world_size` cancels that
+        # mean, making the synchronized gradient the exact global token-mean
+        # gradient regardless of world size.
+        local_loss = (loss_dict["v_weight"] * l_v + loss_dict["p_weight"] * l_p) * (
+            float(reduce_world_size) / denom
+        )
         backward_ts = time.time()
-        loss.backward()
+        local_loss.backward()
         self.record_training_timing("timing_s/drafter_backward", time.time() - backward_ts)
 
         # 更新权重


### PR DESCRIPTION
## What

The drafter loss aggregation in `_training_step_on_batch` all-reduces the per-rank loss and token sums, then divides by the global token count and calls `backward()` on that value. `dist.all_reduce` is not autograd-aware, so each rank's backward only carries its own local contribution divided by the global token count. FSDP's gradient reduction then averages across ranks on top of that, so the synchronized gradient ends up divided by the participating world size: a W-rank run silently trains with an effective learning rate of `lr / W`, and results change with the number of ranks. Early in training the `max_norm=1.0` gradient clip masks the difference; once gradients shrink below the clip threshold, convergence quietly slows down.

## Fix

- Factor the metric reduction into `_reduce_loss_metrics`, which all-reduces detached sums and reports the participating world size. The reduced values are used only for the skip guards and logging, exactly as before.
- Run backward on this rank's local loss sums scaled by `reduce_world_size / global_tokens`. FSDP's gradient mean over the same ranks cancels the scale factor, so the synchronized gradient equals the exact global token-mean gradient regardless of world size. Single-rank behavior is unchanged.

The bookkeeping matches both FSDP wrap paths: the FSDP2 mesh covers dp x sp (the sp and dp reductions multiply to the mesh size), and the FSDP1 path averages over the sp process group for FULL_SHARD or over sp x dp for HYBRID_SHARD.

## Tests

`tests/unit/test_drafter_loss_reduction.py`:
- single-rank passthrough returns detached values and world size 1;
- the world size multiplies sp and dp group sizes;
- an emulated 2-rank DP run asserts that the FSDP-style mean of the per-rank gradients from the scaled local losses equals the gradient of the global token-mean loss (the exact invariant the fix restores).

Full CPU suite (`tests/unit`, `tests/integration`, `tests/config`) passes with the same two pre-existing environment-dependent failures as `main` (`test_async_publish_sets_pending_ref_and_waits_before_next_publish`, `test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names`), which fail identically on an unmodified `main` checkout in my local environment.
