### PR TITLE
fix(domino): stop dropping the block mask off CUDA

### DIFF
--- a/tests/integration/test_domino_backend_contract.py
+++ b/tests/integration/test_domino_backend_contract.py
@@ -98,6 +98,51 @@ def test_domino_forward_computes_top5_accuracy() -> None:
     assert top5 > 0
 
 
+def test_domino_forward_passes_dense_mask_off_cuda(monkeypatch) -> None:
+    """Off CUDA there is no flex block mask, so the backend must hand the
+    draft model the dense equivalent; without it SDPA runs unmasked and every
+    draft query sees the target tokens it is supposed to predict."""
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    import torch
+
+    from verl_speco.backends.domino_trainer_backend import DominoTrainingModel
+    from verl_speco.models.domino import DominoDraftModel
+
+    torch.manual_seed(0)
+    config = _tiny_domino_config()
+    model = DominoTrainingModel(
+        draft_model=DominoDraftModel(config),
+        block_size=config.block_size,
+        num_anchors=config.num_anchors,
+        pure_draft_prefix_len=config.pure_draft_prefix_len,
+    )
+
+    captured = {}
+    original_forward = model.draft_model.forward
+
+    def spy(*args, **kwargs):
+        captured.update(kwargs)
+        return original_forward(*args, **kwargs)
+
+    monkeypatch.setattr(model.draft_model, "forward", spy)
+
+    bsz, seq_len = 2, 16
+    input_ids = torch.randint(0, config.vocab_size, (bsz, seq_len))
+    hidden_states_list = [torch.randn(bsz, seq_len, config.target_hidden_size) for _ in config.target_layer_ids]
+    loss_mask = torch.ones(bsz, seq_len, dtype=torch.long)
+    lm_head_weight = torch.randn(config.vocab_size, config.hidden_size)
+
+    model(input_ids, hidden_states_list, loss_mask, lm_head_weight)
+
+    assert captured["block_mask"] is None
+    dense_mask = captured["dense_attention_mask"]
+    assert dense_mask is not None
+    draft_len = config.num_anchors * config.block_size
+    assert dense_mask.shape == (bsz, 1, draft_len, seq_len + draft_len)
+    assert dense_mask.dtype == torch.bool
+
+
 def test_domino_lambda_base_schedule() -> None:
     # get_lambda_base is pure-python, but its module (domino_trainer_backend)
     # subclasses the torch-based DFlash backend at import time, so it cannot be

--- a/verl_speco/backends/domino_trainer_backend.py
+++ b/verl_speco/backends/domino_trainer_backend.py
@@ -37,6 +37,7 @@ import torch.nn.functional as F
 from verl_speco.backends.dflash_trainer_backend import (
     DFlashTrainerBackend,
     DFlashTrainingModel,
+    _create_dflash_dense_attention_mask,
     _create_dflash_mask_mod,
 )
 from verl_speco.models.dflash.flex_attention import compile_friendly_create_block_mask
@@ -158,6 +159,7 @@ class DominoTrainingModel(DFlashTrainingModel):
         draft_len = n_blocks * self.block_size
 
         block_mask = None
+        dense_attention_mask = None
         if device.type == "cuda":
             block_mask = compile_friendly_create_block_mask(
                 mask_mod=_create_dflash_mask_mod(anchor_positions, block_keep_mask, seq_len, self.block_size),
@@ -167,6 +169,13 @@ class DominoTrainingModel(DFlashTrainingModel):
                 KV_LEN=seq_len + draft_len,
                 device=device,
             )
+        else:
+            dense_attention_mask = _create_dflash_dense_attention_mask(
+                anchor_positions,
+                block_keep_mask,
+                seq_len,
+                self.block_size,
+            )
 
         draft_hidden = self.draft_model(
             draft_input_ids=None,
@@ -174,6 +183,7 @@ class DominoTrainingModel(DFlashTrainingModel):
             draft_position_ids=draft_position_ids,
             context_position_ids=context_position_ids,
             block_mask=block_mask,
+            dense_attention_mask=dense_attention_mask,
             noise_embedding=noise_embedding,
         ).view(bsz, n_blocks, self.block_size, -1)
 


### PR DESCRIPTION
## What

DFlash and DSpark fall back to the dense equivalent of the flex block mask when the device is not CUDA, but the Domino backend still built the mask only under `device.type == "cuda"` and passed nothing otherwise. `DFlashAttention` then runs `scaled_dot_product_attention` with `attn_mask=None` and `is_causal=False`, so every draft query attends to the whole context, including the target tokens it is being trained to predict and every other draft block. On NPU or CPU the loss collapses by copying the leaked targets and the trained drafter is useless, with no error raised.

## Fix

Wire the shared `_create_dflash_dense_attention_mask` fallback into the Domino forward, exactly mirroring the DFlash backend's else branch, and pass `dense_attention_mask` through to the draft model (Domino inherits the DFlash forward, which already threads it into every layer).

## Tests

`test_domino_forward_passes_dense_mask_off_cuda` asserts that off CUDA the backend hands the draft model a boolean dense mask of shape `[bsz, 1, draft_len, seq_len + draft_len]` and no flex block mask. The existing CPU forward test now also exercises the masked path instead of unmasked attention.
