### PR TITLE
fix(data): survive partial cache args and fix a tautological role check

### DIFF
--- a/tests/unit/test_build_eagle3_dataset_cache_args.py
+++ b/tests/unit/test_build_eagle3_dataset_cache_args.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("datasets")
+
+from verl_speco.data.preprocessing import build_eagle3_dataset
+
+
+class _FakeDataset:
+    """Minimal stand-in: build_eagle3_dataset only shuffles, maps, and formats."""
+
+    column_names = ["conversations"]
+
+    def __init__(self):
+        self.map_kwargs = None
+
+    def shuffle(self, seed=None):
+        return self
+
+    def map(self, fn, **kwargs):
+        self.map_kwargs = kwargs
+        return self
+
+    def set_format(self, type=None):
+        return self
+
+
+def _build(dataset, **cache_kwargs):
+    return build_eagle3_dataset(
+        dataset=dataset,
+        tokenizer=None,
+        chat_template="qwen",
+        num_proc=1,
+        **cache_kwargs,
+    )
+
+
+def test_no_cache_args_disables_caching():
+    dataset = _FakeDataset()
+    _build(dataset)
+    assert dataset.map_kwargs["load_from_cache_file"] is False
+    assert dataset.map_kwargs["cache_file_name"] is None
+
+
+def test_both_cache_args_enable_caching(tmp_path):
+    dataset = _FakeDataset()
+    cache_dir = str(tmp_path / "cache")
+    _build(dataset, cache_dir=cache_dir, cache_key="unit")
+    assert dataset.map_kwargs["load_from_cache_file"] is True
+    assert dataset.map_kwargs["cache_file_name"] == os.path.join(cache_dir, "unit.pkl")
+    assert os.path.isdir(cache_dir)
+
+
+@pytest.mark.parametrize("cache_kwargs", [{"cache_dir": "/tmp/x"}, {"cache_key": "unit"}])
+def test_partial_cache_args_warn_and_fall_back(cache_kwargs):
+    """A single cache argument used to leave load_from_cache_file/cache_file_name
+    unbound and crash dataset.map with UnboundLocalError."""
+    dataset = _FakeDataset()
+    with pytest.warns(UserWarning, match="must be provided together"):
+        _build(dataset, **cache_kwargs)
+    assert dataset.map_kwargs["load_from_cache_file"] is False
+    assert dataset.map_kwargs["cache_file_name"] is None

--- a/verl_speco/data/parse.py
+++ b/verl_speco/data/parse.py
@@ -352,7 +352,7 @@ class HarmonyParser(Parser):
             for j, message in enumerate(conversation):
                 if j == 0 and (
                     message["role"] != "system"
-                    or message["role"] != "assistant_reasoning_effort"
+                    and message["role"] != "assistant_reasoning_effort"
                 ):
                     prompt_text = self.build_single_turn_prompt(
                         prompt_text,

--- a/verl_speco/data/parse.py
+++ b/verl_speco/data/parse.py
@@ -350,9 +350,9 @@ class HarmonyParser(Parser):
         if not preformatted:
             prompt_text = ""
             for j, message in enumerate(conversation):
-                if j == 0 and (
-                    message["role"] != "system"
-                    and message["role"] != "assistant_reasoning_effort"
+                if j == 0 and message["role"] not in (
+                    "system",
+                    "assistant_reasoning_effort",
                 ):
                     prompt_text = self.build_single_turn_prompt(
                         prompt_text,

--- a/verl_speco/data/preprocessing.py
+++ b/verl_speco/data/preprocessing.py
@@ -427,7 +427,7 @@ def build_eagle3_dataset(
         cache_file_name = os.path.join(cache_dir, f"{cache_key}.pkl")
         print(f"dataset is cached at {cache_file_name}")
     else:
-        if not (cache_dir is None and cache_key is None):
+        if cache_dir is not None or cache_key is not None:
             warnings.warn(
                 "cache_dir and cache_key must be provided together to make caching work; proceeding without caching"
             )

--- a/verl_speco/data/preprocessing.py
+++ b/verl_speco/data/preprocessing.py
@@ -426,14 +426,14 @@ def build_eagle3_dataset(
         os.makedirs(cache_dir, exist_ok=True)
         cache_file_name = os.path.join(cache_dir, f"{cache_key}.pkl")
         print(f"dataset is cached at {cache_file_name}")
-    elif cache_dir is None and cache_key is None:
+    else:
+        if not (cache_dir is None and cache_key is None):
+            warnings.warn(
+                "cache_dir and cache_key must be provided together to make caching work; proceeding without caching"
+            )
         load_from_cache_file = False
         cache_file_name = None
-        print(f"dataset is not cached")
-    else:
-        warnings.warn(
-            f"cache_dir and cache_key must be provided together to make caching work"
-        )
+        print("dataset is not cached")
 
     # Disable tokenizers internal parallelism when using multiprocessing to avoid
     # deadlocks caused by forked Rust threads (see huggingface/tokenizers#1391).


### PR DESCRIPTION
## What

Two small data-layer fixes.

1. `build_eagle3_dataset` crashed with `UnboundLocalError` when exactly one of `cache_dir` / `cache_key` was provided: the mismatch branch only emitted a warning and never assigned `load_from_cache_file` / `cache_file_name`, which `dataset.map(...)` then referenced.
2. The `HarmonyParser` first-turn guard used `or` between two inequality checks, so the condition was always true and the default reasoning-effort block was injected for every first message.

## Fix

1. Fold the mismatch case into the no-cache path: warn and proceed without caching instead of crashing.
2. Change the guard to `and`, matching the intent (skip injection when the conversation already opens with a system or reasoning-effort message). Behavior is unchanged today because the `system` and `assistant_reasoning_effort` branches of `build_single_turn_prompt` overwrite `prompt_text` rather than append, which masked the extra injection; the condition now encodes the intent instead of relying on that masking.

## Tests

`tests/unit/test_build_eagle3_dataset_cache_args.py` covers all three cache argument combinations: both provided (caching on, `.pkl` path, cache dir created), neither provided (caching off), and each partial combination (warns, falls back to no caching, no crash).
