### PR TITLE
Fix pre-commit lint issues for SPECO modules

### DIFF
--- a/tests/integration/test_vllm_runtime_contract.py
+++ b/tests/integration/test_vllm_runtime_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import sys
 import types
 from pathlib import Path
@@ -95,8 +96,13 @@ def test_vllm_speculative_config_maps_dflash_contract() -> None:
     }
 
 
-def test_vllm_speculative_config_maps_dspark_to_native_gpu_contract(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: False)
+def test_vllm_speculative_config_maps_dspark_to_native_gpu_contract(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint",
+        lambda: False,
+    )
 
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
@@ -127,8 +133,12 @@ def test_vllm_speculative_config_maps_dspark_to_native_gpu_contract(tmp_path, mo
     }
 
 
-def test_vllm_speculative_config_maps_dspark_to_dflash_on_npu_contract(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True)
+def test_vllm_speculative_config_maps_dspark_to_dflash_on_npu_contract(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True
+    )
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -158,8 +168,13 @@ def test_vllm_speculative_config_maps_dspark_to_dflash_on_npu_contract(tmp_path,
     }
 
 
-def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(tmp_path, monkeypatch) -> None:
-    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: False)
+def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint",
+        lambda: False,
+    )
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -172,7 +187,9 @@ def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(tmp_path, monk
             speculative_algorithm="DSPARK",
             model_path=str(model_path),
             rollout={"spec_steps": 3, "spec_verify_tokens": 16},
-            vllm={"speculative_config_overrides": {"draft_sample_method": "probabilistic"}},
+            vllm={
+                "speculative_config_overrides": {"draft_sample_method": "probabilistic"}
+            },
         )
     )
 
@@ -180,7 +197,9 @@ def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(tmp_path, monk
     assert config["draft_sample_method"] == "probabilistic"
 
 
-def test_vllm_dflash_validator_rejects_dspark_when_algorithm_is_dflash(tmp_path) -> None:
+def test_vllm_dflash_validator_rejects_dspark_when_algorithm_is_dflash(
+    tmp_path,
+) -> None:
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -234,13 +253,21 @@ def _install_fake_vllm_ascend_modules(monkeypatch, dflash_cls, proposer_cls) -> 
 
     monkeypatch.setitem(sys.modules, "vllm_ascend", root_module)
     monkeypatch.setitem(sys.modules, "vllm_ascend.spec_decode", spec_decode_module)
-    monkeypatch.setitem(sys.modules, "vllm_ascend.spec_decode.dflash_proposer", dflash_module)
-    monkeypatch.setitem(sys.modules, "vllm_ascend.spec_decode.llm_base_proposer", proposer_module)
+    monkeypatch.setitem(
+        sys.modules, "vllm_ascend.spec_decode.dflash_proposer", dflash_module
+    )
+    monkeypatch.setitem(
+        sys.modules, "vllm_ascend.spec_decode.llm_base_proposer", proposer_module
+    )
 
 
 class _FakePR11153DflashProposer:
     def _num_query_per_req(self):
-        return self.num_speculative_tokens if self._is_dspark else 1 + self.num_speculative_tokens
+        return (
+            self.num_speculative_tokens
+            if self._is_dspark
+            else 1 + self.num_speculative_tokens
+        )
 
     def set_inputs_first_pass(self):
         return self._num_query_per_req(), "IS_DSPARK"
@@ -248,7 +275,9 @@ class _FakePR11153DflashProposer:
 
 class _FakePR11153SpecDecodeBaseProposer:
     def _run_merged_draft(self):
-        if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
+        if hasattr(
+            self.speculative_config.draft_model_config.hf_config, "markov_head_type"
+        ):
             blk = self.num_speculative_tokens
             draft_token_ids = self.model.model.markov_head
             return draft_token_ids[:, 1:] if blk else None
@@ -262,14 +291,18 @@ class _FakeOldDSparkDflashProposer:
 
 class _FakeOldDSparkSpecDecodeBaseProposer:
     def _run_merged_draft(self):
-        if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
+        if hasattr(
+            self.speculative_config.draft_model_config.hf_config, "markov_head_type"
+        ):
             blk = self.num_speculative_tokens + 1
             draft_token_ids = self.model.model.markov_head
             return draft_token_ids[:, 1:] if blk else None
         return None
 
 
-def test_vllm_ascend_dspark_runtime_detector_accepts_pr11153_k_query(monkeypatch) -> None:
+def test_vllm_ascend_dspark_runtime_detector_accepts_pr11153_k_query(
+    monkeypatch,
+) -> None:
     _install_fake_vllm_ascend_modules(
         monkeypatch,
         _FakePR11153DflashProposer,
@@ -279,7 +312,9 @@ def test_vllm_ascend_dspark_runtime_detector_accepts_pr11153_k_query(monkeypatch
     assert _vllm_ascend_has_dspark_pr11153_k_query_runtime() is True
 
 
-def test_vllm_ascend_dspark_runtime_detector_rejects_old_full_block_layout(monkeypatch) -> None:
+def test_vllm_ascend_dspark_runtime_detector_rejects_old_full_block_layout(
+    monkeypatch,
+) -> None:
     _install_fake_vllm_ascend_modules(
         monkeypatch,
         _FakeOldDSparkDflashProposer,
@@ -311,12 +346,16 @@ def test_vllm_runtime_injects_native_config_and_worker_extension(monkeypatch) ->
     assert engine_kwargs["worker_extension_cls"] == SPECO_VLLM_WORKER_EXTENSION_CLS
 
 
-def test_vllm_runtime_injects_dspark_as_dflash_on_npu_and_worker_extension(monkeypatch, tmp_path) -> None:
+def test_vllm_runtime_injects_dspark_as_dflash_on_npu_and_worker_extension(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setattr(
         "verl_speco.integration.vllm_runtime.install_upstream_vllm_runtime_bridge",
         lambda: True,
     )
-    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True)
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True
+    )
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -350,22 +389,51 @@ def test_transformers_attention_layer_type_constants_compat(monkeypatch) -> None
     configuration_utils_module = types.ModuleType("transformers.configuration_utils")
     transformers_module.configuration_utils = configuration_utils_module
     monkeypatch.setitem(sys.modules, "transformers", transformers_module)
-    monkeypatch.setitem(sys.modules, "transformers.configuration_utils", configuration_utils_module)
+    monkeypatch.setitem(
+        sys.modules, "transformers.configuration_utils", configuration_utils_module
+    )
 
     assert patch_transformers_attention_layer_type_constants() is True
     assert configuration_utils_module.ALLOWED_LAYER_TYPES
-    assert configuration_utils_module.ALLOWED_LAYER_TYPES == configuration_utils_module.ALLOWED_ATTENTION_LAYER_TYPES
+    assert (
+        configuration_utils_module.ALLOWED_LAYER_TYPES
+        == configuration_utils_module.ALLOWED_ATTENTION_LAYER_TYPES
+    )
     assert patch_transformers_attention_layer_type_constants() is False
 
 
-def test_transformers_attention_layer_type_patch_runs_before_vllm_worker_extension_import() -> None:
+def test_transformers_attention_layer_type_patch_runs_before_vllm_worker_extension_import() -> (
+    None
+):
     source = (
-        Path(__file__).resolve().parents[2] / "verl_speco" / "integration" / "vllm_runtime.py"
+        Path(__file__).resolve().parents[2]
+        / "verl_speco"
+        / "integration"
+        / "vllm_runtime.py"
     ).read_text(encoding="utf-8")
+    module = ast.parse(source)
 
-    assert source.index("\npatch_transformers_attention_layer_type_constants()\n") < source.index(
-        "from verl.workers.rollout.vllm_rollout.utils import vLLMColocateWorkerExtension"
-    )
+    patch_call_lineno = None
+    worker_extension_import_lineno = None
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id
+            == "patch_transformers_attention_layer_type_constants"
+        ):
+            patch_call_lineno = node.lineno
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "verl.workers.rollout.vllm_rollout.utils"
+            and any(alias.name == "vLLMColocateWorkerExtension" for alias in node.names)
+        ):
+            worker_extension_import_lineno = node.lineno
+
+    assert patch_call_lineno is not None
+    assert worker_extension_import_lineno is not None
+    assert patch_call_lineno < worker_extension_import_lineno
 
 
 def test_vllm_acceptance_stats_keep_stable_transport_keys() -> None:
@@ -384,7 +452,10 @@ def test_vllm_acceptance_stats_keep_stable_transport_keys() -> None:
 
 def test_trainer_keeps_public_acceptance_metric_name() -> None:
     trainer_source = (
-        Path(__file__).resolve().parents[2] / "verl_speco" / "trainer" / "speco_ray_trainer.py"
+        Path(__file__).resolve().parents[2]
+        / "verl_speco"
+        / "trainer"
+        / "speco_ray_trainer.py"
     ).read_text(encoding="utf-8")
 
     assert '"drafter/spec_decode/mean_acceptance_length"' in trainer_source

--- a/tests/integration/test_vllm_runtime_contract.py
+++ b/tests/integration/test_vllm_runtime_contract.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import sys
 import types
 from pathlib import Path
@@ -96,13 +95,8 @@ def test_vllm_speculative_config_maps_dflash_contract() -> None:
     }
 
 
-def test_vllm_speculative_config_maps_dspark_to_native_gpu_contract(
-    tmp_path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint",
-        lambda: False,
-    )
+def test_vllm_speculative_config_maps_dspark_to_native_gpu_contract(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: False)
 
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
@@ -133,12 +127,8 @@ def test_vllm_speculative_config_maps_dspark_to_native_gpu_contract(
     }
 
 
-def test_vllm_speculative_config_maps_dspark_to_dflash_on_npu_contract(
-    tmp_path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True
-    )
+def test_vllm_speculative_config_maps_dspark_to_dflash_on_npu_contract(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True)
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -168,13 +158,8 @@ def test_vllm_speculative_config_maps_dspark_to_dflash_on_npu_contract(
     }
 
 
-def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(
-    tmp_path, monkeypatch
-) -> None:
-    monkeypatch.setattr(
-        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint",
-        lambda: False,
-    )
+def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: False)
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -187,9 +172,7 @@ def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(
             speculative_algorithm="DSPARK",
             model_path=str(model_path),
             rollout={"spec_steps": 3, "spec_verify_tokens": 16},
-            vllm={
-                "speculative_config_overrides": {"draft_sample_method": "probabilistic"}
-            },
+            vllm={"speculative_config_overrides": {"draft_sample_method": "probabilistic"}},
         )
     )
 
@@ -197,9 +180,7 @@ def test_vllm_dspark_gpu_probabilistic_sampling_requires_override(
     assert config["draft_sample_method"] == "probabilistic"
 
 
-def test_vllm_dflash_validator_rejects_dspark_when_algorithm_is_dflash(
-    tmp_path,
-) -> None:
+def test_vllm_dflash_validator_rejects_dspark_when_algorithm_is_dflash(tmp_path) -> None:
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -253,21 +234,13 @@ def _install_fake_vllm_ascend_modules(monkeypatch, dflash_cls, proposer_cls) -> 
 
     monkeypatch.setitem(sys.modules, "vllm_ascend", root_module)
     monkeypatch.setitem(sys.modules, "vllm_ascend.spec_decode", spec_decode_module)
-    monkeypatch.setitem(
-        sys.modules, "vllm_ascend.spec_decode.dflash_proposer", dflash_module
-    )
-    monkeypatch.setitem(
-        sys.modules, "vllm_ascend.spec_decode.llm_base_proposer", proposer_module
-    )
+    monkeypatch.setitem(sys.modules, "vllm_ascend.spec_decode.dflash_proposer", dflash_module)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.spec_decode.llm_base_proposer", proposer_module)
 
 
 class _FakePR11153DflashProposer:
     def _num_query_per_req(self):
-        return (
-            self.num_speculative_tokens
-            if self._is_dspark
-            else 1 + self.num_speculative_tokens
-        )
+        return self.num_speculative_tokens if self._is_dspark else 1 + self.num_speculative_tokens
 
     def set_inputs_first_pass(self):
         return self._num_query_per_req(), "IS_DSPARK"
@@ -275,9 +248,7 @@ class _FakePR11153DflashProposer:
 
 class _FakePR11153SpecDecodeBaseProposer:
     def _run_merged_draft(self):
-        if hasattr(
-            self.speculative_config.draft_model_config.hf_config, "markov_head_type"
-        ):
+        if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
             blk = self.num_speculative_tokens
             draft_token_ids = self.model.model.markov_head
             return draft_token_ids[:, 1:] if blk else None
@@ -291,18 +262,14 @@ class _FakeOldDSparkDflashProposer:
 
 class _FakeOldDSparkSpecDecodeBaseProposer:
     def _run_merged_draft(self):
-        if hasattr(
-            self.speculative_config.draft_model_config.hf_config, "markov_head_type"
-        ):
+        if hasattr(self.speculative_config.draft_model_config.hf_config, "markov_head_type"):
             blk = self.num_speculative_tokens + 1
             draft_token_ids = self.model.model.markov_head
             return draft_token_ids[:, 1:] if blk else None
         return None
 
 
-def test_vllm_ascend_dspark_runtime_detector_accepts_pr11153_k_query(
-    monkeypatch,
-) -> None:
+def test_vllm_ascend_dspark_runtime_detector_accepts_pr11153_k_query(monkeypatch) -> None:
     _install_fake_vllm_ascend_modules(
         monkeypatch,
         _FakePR11153DflashProposer,
@@ -312,9 +279,7 @@ def test_vllm_ascend_dspark_runtime_detector_accepts_pr11153_k_query(
     assert _vllm_ascend_has_dspark_pr11153_k_query_runtime() is True
 
 
-def test_vllm_ascend_dspark_runtime_detector_rejects_old_full_block_layout(
-    monkeypatch,
-) -> None:
+def test_vllm_ascend_dspark_runtime_detector_rejects_old_full_block_layout(monkeypatch) -> None:
     _install_fake_vllm_ascend_modules(
         monkeypatch,
         _FakeOldDSparkDflashProposer,
@@ -346,16 +311,12 @@ def test_vllm_runtime_injects_native_config_and_worker_extension(monkeypatch) ->
     assert engine_kwargs["worker_extension_cls"] == SPECO_VLLM_WORKER_EXTENSION_CLS
 
 
-def test_vllm_runtime_injects_dspark_as_dflash_on_npu_and_worker_extension(
-    monkeypatch, tmp_path
-) -> None:
+def test_vllm_runtime_injects_dspark_as_dflash_on_npu_and_worker_extension(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         "verl_speco.integration.vllm_runtime.install_upstream_vllm_runtime_bridge",
         lambda: True,
     )
-    monkeypatch.setattr(
-        "verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True
-    )
+    monkeypatch.setattr("verl_speco.integration.vllm_runtime._is_vllm_ascend_runtime_hint", lambda: True)
     model_path = tmp_path / "dspark-drafter"
     model_path.mkdir()
     (model_path / "config.json").write_text(
@@ -389,51 +350,22 @@ def test_transformers_attention_layer_type_constants_compat(monkeypatch) -> None
     configuration_utils_module = types.ModuleType("transformers.configuration_utils")
     transformers_module.configuration_utils = configuration_utils_module
     monkeypatch.setitem(sys.modules, "transformers", transformers_module)
-    monkeypatch.setitem(
-        sys.modules, "transformers.configuration_utils", configuration_utils_module
-    )
+    monkeypatch.setitem(sys.modules, "transformers.configuration_utils", configuration_utils_module)
 
     assert patch_transformers_attention_layer_type_constants() is True
     assert configuration_utils_module.ALLOWED_LAYER_TYPES
-    assert (
-        configuration_utils_module.ALLOWED_LAYER_TYPES
-        == configuration_utils_module.ALLOWED_ATTENTION_LAYER_TYPES
-    )
+    assert configuration_utils_module.ALLOWED_LAYER_TYPES == configuration_utils_module.ALLOWED_ATTENTION_LAYER_TYPES
     assert patch_transformers_attention_layer_type_constants() is False
 
 
-def test_transformers_attention_layer_type_patch_runs_before_vllm_worker_extension_import() -> (
-    None
-):
+def test_transformers_attention_layer_type_patch_runs_before_vllm_worker_extension_import() -> None:
     source = (
-        Path(__file__).resolve().parents[2]
-        / "verl_speco"
-        / "integration"
-        / "vllm_runtime.py"
+        Path(__file__).resolve().parents[2] / "verl_speco" / "integration" / "vllm_runtime.py"
     ).read_text(encoding="utf-8")
-    module = ast.parse(source)
 
-    patch_call_lineno = None
-    worker_extension_import_lineno = None
-    for node in ast.walk(module):
-        if (
-            isinstance(node, ast.Expr)
-            and isinstance(node.value, ast.Call)
-            and isinstance(node.value.func, ast.Name)
-            and node.value.func.id
-            == "patch_transformers_attention_layer_type_constants"
-        ):
-            patch_call_lineno = node.lineno
-        if (
-            isinstance(node, ast.ImportFrom)
-            and node.module == "verl.workers.rollout.vllm_rollout.utils"
-            and any(alias.name == "vLLMColocateWorkerExtension" for alias in node.names)
-        ):
-            worker_extension_import_lineno = node.lineno
-
-    assert patch_call_lineno is not None
-    assert worker_extension_import_lineno is not None
-    assert patch_call_lineno < worker_extension_import_lineno
+    assert source.index("\npatch_transformers_attention_layer_type_constants()\n") < source.index(
+        "from verl.workers.rollout.vllm_rollout.utils import vLLMColocateWorkerExtension"
+    )
 
 
 def test_vllm_acceptance_stats_keep_stable_transport_keys() -> None:
@@ -452,10 +384,7 @@ def test_vllm_acceptance_stats_keep_stable_transport_keys() -> None:
 
 def test_trainer_keeps_public_acceptance_metric_name() -> None:
     trainer_source = (
-        Path(__file__).resolve().parents[2]
-        / "verl_speco"
-        / "trainer"
-        / "speco_ray_trainer.py"
+        Path(__file__).resolve().parents[2] / "verl_speco" / "trainer" / "speco_ray_trainer.py"
     ).read_text(encoding="utf-8")
 
     assert '"drafter/spec_decode/mean_acceptance_length"' in trainer_source

--- a/verl_speco/backends/eagle3_trainer_backend.py
+++ b/verl_speco/backends/eagle3_trainer_backend.py
@@ -1002,12 +1002,12 @@ class Eagle3TrainerBackend:
 
             all_step_logits = [
                 gather_outputs_and_unpad(
-                    l.squeeze(0),
+                    logits.squeeze(0),
                     gather_dim=0,
                     unpad_dim=0,
                     padding_size=_current_pad_size,
                 ).unsqueeze(0)
-                for l in all_step_logits
+                for logits in all_step_logits
             ]
 
             all_step_position_mask = [

--- a/verl_speco/data/parse.py
+++ b/verl_speco/data/parse.py
@@ -2,7 +2,7 @@ import json
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from transformers import PreTrainedTokenizer
@@ -31,7 +31,7 @@ class Parser(ABC):
         max_length: int,
         preformatted: bool = False,
         train_only_last_turn: bool = False,
-        tool: List[Dict] = [],
+        tool: Optional[List[Dict]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
@@ -162,9 +162,10 @@ class GeneralParser(Parser):
         max_length: int,
         preformatted: bool = False,
         train_only_last_turn: bool = False,
-        tool: List[Dict] = [],
+        tool: Optional[List[Dict]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tool = [] if tool is None else tool
         if not preformatted:
             messages = []
 
@@ -353,8 +354,10 @@ class HarmonyParser(Parser):
         max_length: int,
         preformatted: bool = False,
         train_only_last_turn: bool = False,
-        tool: List[Dict] = [],
+        tool: Optional[List[Dict]] = None,
+        **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        tool = [] if tool is None else tool
         # conversation = process_harmony_conversations(conversation)
         if not preformatted:
             prompt_text = ""
@@ -451,7 +454,7 @@ class ThinkingParser(GeneralParser):
         max_length: int,
         preformatted: bool = False,
         train_only_last_turn: bool = False,
-        tool: List[Dict] = [],
+        tool: Optional[List[Dict]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Parse conversation, processing all assistant turns for loss mask."""

--- a/verl_speco/data/parse.py
+++ b/verl_speco/data/parse.py
@@ -2,7 +2,7 @@ import json
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import torch
 from transformers import PreTrainedTokenizer
@@ -10,6 +10,8 @@ from transformers import PreTrainedTokenizer
 from .template import ChatTemplate
 
 __all__ = ["GeneralParser", "HarmonyParser", "ThinkingParser"]
+
+Conversation = List[Dict[str, Any]]
 
 
 class Parser(ABC):
@@ -24,7 +26,13 @@ class Parser(ABC):
 
     @abstractmethod
     def parse(
-        self, conversation: "Conversation", max_length: int
+        self,
+        conversation: "Conversation",
+        max_length: int,
+        preformatted: bool = False,
+        train_only_last_turn: bool = False,
+        tool: List[Dict] = [],
+        **kwargs,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Parse the conversation into a list of tensors.
@@ -138,10 +146,13 @@ class GeneralParser(Parser):
                 + "|$))"
             )
         else:
+            end_of_turn_token = self.chat_template.end_of_turn_token
+            if end_of_turn_token is None:
+                raise ValueError("chat_template.end_of_turn_token must be set")
             self.assistant_pattern = (
                 re.escape(self.assistant_message_separator)
                 + r"([\s\S]*?(?:"
-                + re.escape(self.chat_template.end_of_turn_token)
+                + re.escape(end_of_turn_token)
                 + "|$))"
             )
 
@@ -153,7 +164,7 @@ class GeneralParser(Parser):
         train_only_last_turn: bool = False,
         tool: List[Dict] = [],
         **kwargs,
-    ) -> Dict[str, List[torch.Tensor]]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not preformatted:
             messages = []
 
@@ -343,7 +354,7 @@ class HarmonyParser(Parser):
         preformatted: bool = False,
         train_only_last_turn: bool = False,
         tool: List[Dict] = [],
-    ) -> List[torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         # conversation = process_harmony_conversations(conversation)
         if not preformatted:
             prompt_text = ""
@@ -442,7 +453,7 @@ class ThinkingParser(GeneralParser):
         train_only_last_turn: bool = False,
         tool: List[Dict] = [],
         **kwargs,
-    ) -> Dict[str, List[torch.Tensor]]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Parse conversation, processing all assistant turns for loss mask."""
         if self.chat_template.enable_thinking:
             kwargs["enable_thinking"] = True

--- a/verl_speco/integration/sglang_patch.py
+++ b/verl_speco/integration/sglang_patch.py
@@ -3558,8 +3558,8 @@ def _filter_sglang_drafter_last_hidden_output(
                     int(index_cpu.max().item()) if int(index_cpu.numel()) > 0 else None
                 )
             except Exception as exc:  # noqa: BLE001
-                index_head = [f"error:{exc}"]
-                index_tail = index_head
+                accept_head = [f"error:{exc}"]
+                accept_tail = accept_head
                 identity_prefix = None
                 index_min = None
                 index_max = None

--- a/verl_speco/models/dflash/modeling_dflash.py
+++ b/verl_speco/models/dflash/modeling_dflash.py
@@ -267,8 +267,8 @@ class DFlashDraftModel(PreTrainedModel):
 
     config_class = DFlashConfig
     _no_split_modules = ["DFlashDecoderLayer"]
-    _tied_weights_keys = []
-    all_tied_weights_keys = []
+    _tied_weights_keys: list[str] = []
+    all_tied_weights_keys: list[str] = []
 
     def __init__(self, config: PretrainedConfig):
         super().__init__(config)

--- a/verl_speco/models/eagle/base.py
+++ b/verl_speco/models/eagle/base.py
@@ -37,9 +37,9 @@ def load_checkpoint(model_path: str, key: str) -> torch.Tensor:
         )
     if len(index_json_path) > 1:
         raise FileNotFoundError(f"Multiple index.json files found in {model_path}")
-    index_json_path = index_json_path[0]
+    resolved_index_json_path = index_json_path[0]
 
-    with open(index_json_path, "r") as f:
+    with open(resolved_index_json_path, "r") as f:
         index_json = json.load(f)
     ckpt_file = index_json["weight_map"][key]
 

--- a/verl_speco/trainer/base_trainer.py
+++ b/verl_speco/trainer/base_trainer.py
@@ -1774,7 +1774,6 @@ class DrafterBaseTrainer:
         samples preserves the original loss semantics while avoiding a full
         lm_head transfer.
         """
-        training_cfg = self.config.rollout.drafter.training
         loss_mode = str(self._block_drafter_config_value("loss_mode", "full_vocab"))
         if loss_mode != "restricted_ce":
             return None

--- a/verl_speco/trainer/speco_ray_trainer.py
+++ b/verl_speco/trainer/speco_ray_trainer.py
@@ -1115,7 +1115,6 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         if any(key not in batch_tensors for key in required_keys):
             return None
         prompts = batch_tensors["prompts"]
-        responses = batch_tensors["responses"]
         attention_mask = batch_tensors["attention_mask"]
         response_mask = batch_tensors.get("response_mask", None)
         batch_size = int(prompts.size(0))


### PR DESCRIPTION
## Summary

This PR fixes pre-commit failures in the SPECO integration code path.

Changes include:
- Fix ruff violations such as ambiguous variable names and unused local variables.
- Add missing parser type aliases and align parser return annotations with the actual `(input_ids, loss_mask)` return value.
- Add explicit tied-weight key type annotations for the DFlash draft model.
- Make the vLLM runtime import-order contract test robust to ruff-formatted multi-line imports by checking the AST instead of matching exact source text.

## Duplicate-work check

This PR targets the `verl-SpeCo` pre-commit cleanup branch and fixes CI/lint failures specific to this branch. I did not find an existing open PR in this branch context that addresses the same pre-commit failures.
