### PR TITLE
feat(dspark): add request-aware hard sample collection for drafter training

### DIFF
--- a/examples/run_qwen3-8b_drafter_dspark_vllm_npu.sh
+++ b/examples/run_qwen3-8b_drafter_dspark_vllm_npu.sh
@@ -16,6 +16,12 @@ TRAIN_FILE=/path/to/train_file
 TEST_FILE=/path/to/test_file
 DRAFTER_PATH=/path/to/vllm-compatible-dspark-drafter
 
+# Request-level speculative acceptance statistics.
+REQUEST_ACCEPT_LEN_LOG_PATH=${REQUEST_ACCEPT_LEN_LOG_PATH:-./logs/${exp_name}_request_accept_len_hist.jsonl}
+mkdir -p "$(dirname "${REQUEST_ACCEPT_LEN_LOG_PATH}")"
+export VERL_SPECO_REQUEST_ACCEPT_LEN_HIST_LOG_PATH="${REQUEST_ACCEPT_LEN_LOG_PATH}"
+export VERL_SPECO_REQUEST_ACCEPT_LEN_HIST_PRINT=0
+
 
 PYTHONUNBUFFERED=1 python3 -m verl_speco.main \
     algorithm.adv_estimator=grpo \
@@ -67,6 +73,7 @@ PYTHONUNBUFFERED=1 python3 -m verl_speco.main \
     actor_rollout_ref.rollout.drafter.speculative_algorithm=DSPARK \
     actor_rollout_ref.rollout.drafter.training.collect_hidden_states_from_old_logprob=True \
     actor_rollout_ref.rollout.drafter.training.old_logprob_hidden_capture_impl=forward_hook \
+    actor_rollout_ref.rollout.drafter.training.request_accept_len_variance_interval_steps=0 \
     actor_rollout_ref.rollout.drafter.training.dspark_block_size=7 \
     actor_rollout_ref.rollout.drafter.training.dspark_num_anchors=32 \
     actor_rollout_ref.rollout.drafter.training.dspark_max_window=512 \
@@ -80,6 +87,8 @@ PYTHONUNBUFFERED=1 python3 -m verl_speco.main \
     actor_rollout_ref.rollout.drafter.training.dspark_ce_loss_alpha=0.1 \
     actor_rollout_ref.rollout.drafter.training.dspark_l1_loss_alpha=0.9 \
     actor_rollout_ref.rollout.drafter.training.dspark_confidence_loss_alpha=0.0 \
+    actor_rollout_ref.rollout.drafter.training.dspark_hard_candidate_ratio=0.20 \
+    actor_rollout_ref.rollout.drafter.training.dspark_hard_sample_ratio=0.375 \
     actor_rollout_ref.rollout.drafter.rollout.spec_steps=1 \
     actor_rollout_ref.rollout.drafter.rollout.spec_topk=1 \
     actor_rollout_ref.rollout.drafter.rollout.spec_verify_tokens=7 \

--- a/tests/integration/test_drafter_runtime_control_contract.py
+++ b/tests/integration/test_drafter_runtime_control_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 
 _speco_ray_trainer = pytest.importorskip(
@@ -10,6 +11,7 @@ _speco_ray_trainer = pytest.importorskip(
     reason="drafter runtime control contract needs the trainer dependency stack",
 )
 SpecoRayPPOTrainer = _speco_ray_trainer.SpecoRayPPOTrainer
+from verl_speco.trainer.base_trainer import DrafterBaseTrainer
 
 
 class _FakeOldLogProbBatch:
@@ -36,6 +38,14 @@ class _FakeRolloutWorkerGroup:
     def compute_log_prob(self, batch):
         self.compute_log_prob_calls += 1
         raise AssertionError("non-collect old-logprob steps should use the original compute path")
+
+
+class _ArrayLike:
+    def __init__(self, values):
+        self._values = values
+
+    def tolist(self):
+        return list(self._values)
 
 
 def _trainer(training_cfg: dict, *, step: int = 1) -> SpecoRayPPOTrainer:
@@ -172,6 +182,212 @@ def test_dspark_ce_only_oldlogprob_layout_keeps_aux_only_hidden() -> None:
     trainer.config.actor_rollout_ref.rollout.drafter.speculative_algorithm = "DSPARK"
 
     assert trainer._speco_oldlogprob_hidden_layout() == "dflash_aux"
+
+
+def test_dspark_oldlogprob_collect_plan_uses_request_hard_quota() -> None:
+    trainer = _trainer(
+        {
+            "collect_hidden_states_from_old_logprob": True,
+            "collect_interval_steps": 1,
+            "training_interval_steps": 1,
+            "hidden_state_window_tokens_per_sample": 512,
+            "max_collect_samples_per_step_per_replica": 16,
+            "max_collect_tokens_per_step_per_replica": 16384,
+            "batch_size_per_gpu": 8,
+            "dspark_hard_candidate_ratio": 0.20,
+            "dspark_hard_sample_ratio": 0.375,
+            "hidden_state_window_mode": "random",
+        },
+        step=20,
+    )
+    trainer.config.actor_rollout_ref.actor.strategy = "fsdp2"
+    trainer._speco_online_enabled = lambda: True
+    trainer._speco_owner_bucket_count = lambda: 5
+
+    batch_size = 100
+    prompt_width = 4
+    response_width = 520
+    prompts = torch.ones(batch_size, prompt_width, dtype=torch.long)
+    responses = torch.ones(batch_size, response_width, dtype=torch.long)
+    attention_mask = torch.ones(batch_size, prompt_width + response_width, dtype=torch.long)
+    response_mask = torch.ones(batch_size, response_width, dtype=torch.long)
+    batch = SimpleNamespace(
+        batch={
+            "prompts": prompts,
+            "responses": responses,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+        },
+        non_tensor_batch={
+            "_verl_request_mean_accept_len": [1.0 + index / 1000.0 for index in range(batch_size)],
+            "_speco_vllm_request_id": [f"req-{index}" for index in range(batch_size)],
+            "_speco_vllm_request_completion_index": list(reversed(range(batch_size))),
+        },
+    )
+
+    plan = trainer._speco_build_oldlogprob_collect_plan(batch)
+
+    assert plan["selected_count"] == 80
+    assert int(plan["request_is_hard"].logical_and(plan["collect_mask"]).sum().item()) == 16
+    assert plan["request_is_hard"][:16].all()
+    assert not plan["request_is_hard"][16:].any()
+    assert [int((plan["request_is_hard"] & (plan["owner_rank"] == owner)).sum().item()) for owner in range(5)] == [
+        4,
+        3,
+        3,
+        3,
+        3,
+    ]
+    records = trainer._speco_last_request_accept_len_records
+    assert records[0]["request_id"] == "req-99"
+    assert records[-1]["request_id"] == "req-0"
+    assert plan["request_completion_indices"][0] == 99
+
+
+def test_oldlogprob_collect_plan_accepts_array_like_request_stats() -> None:
+    trainer = _trainer(
+        {
+            "collect_hidden_states_from_old_logprob": True,
+            "collect_interval_steps": 1,
+            "training_interval_steps": 1,
+            "hidden_state_window_tokens_per_sample": 512,
+            "max_collect_samples_per_step_per_replica": 8,
+            "max_collect_tokens_per_step_per_replica": 8192,
+            "batch_size_per_gpu": 4,
+            "dspark_hard_candidate_ratio": 0.5,
+            "dspark_hard_sample_ratio": 0.5,
+            "hidden_state_window_mode": "front",
+        },
+        step=21,
+    )
+    trainer.config.actor_rollout_ref.actor.strategy = "fsdp2"
+    trainer._speco_online_enabled = lambda: True
+    trainer._speco_owner_bucket_count = lambda: 2
+
+    batch_size = 12
+    prompt_width = 4
+    response_width = 520
+    batch = SimpleNamespace(
+        batch={
+            "prompts": torch.ones(batch_size, prompt_width, dtype=torch.long),
+            "responses": torch.ones(batch_size, response_width, dtype=torch.long),
+            "attention_mask": torch.ones(batch_size, prompt_width + response_width, dtype=torch.long),
+            "response_mask": torch.ones(batch_size, response_width, dtype=torch.long),
+        },
+        non_tensor_batch={
+            "_verl_request_mean_accept_len": _ArrayLike([1.0 + index for index in range(batch_size)]),
+            "_speco_vllm_request_id": _ArrayLike([f"req-{index}" for index in range(batch_size)]),
+            "_speco_vllm_request_completion_index": _ArrayLike(range(batch_size)),
+            "_speco_vllm_request_elapsed_sec": _ArrayLike([0.1 * index for index in range(batch_size)]),
+        },
+    )
+
+    plan = trainer._speco_build_oldlogprob_collect_plan(batch)
+
+    assert plan["selected_count"] == 12
+    assert int(plan["request_is_hard"].logical_and(plan["collect_mask"]).sum().item()) == 6
+    assert plan["request_is_hard"][:6].all()
+    assert not plan["request_is_hard"][6:].any()
+    records = trainer._speco_last_request_accept_len_records
+    assert len(records) == batch_size
+    assert records[0]["request_id"] == "req-0"
+    assert records[-1]["request_id"] == "req-11"
+    assert trainer._speco_last_request_accept_len_var > 0.0
+
+
+def test_request_accept_len_variance_logs_without_hard_sampling(capsys) -> None:
+    trainer = _trainer(
+        {
+            "request_accept_len_variance_interval_steps": 2,
+            "dspark_hard_candidate_ratio": 0.0,
+            "dspark_hard_sample_ratio": 0.0,
+        },
+        step=4,
+    )
+
+    batch_size = 4
+    batch = SimpleNamespace(
+        batch={},
+        non_tensor_batch={
+            "_verl_request_mean_accept_len": [1.0, 2.0, 3.0, 4.0],
+            "_speco_vllm_request_id": [f"req-{index}" for index in range(batch_size)],
+        },
+    )
+
+    logged = trainer._speco_log_request_accept_len_variance_from_batch(batch, source="test")
+
+    captured = capsys.readouterr()
+    assert logged is True
+    assert "source=test" in captured.out
+    assert "request_accept_len_var=1.250" in captured.out
+    assert trainer._speco_last_request_accept_len_var == 1.25
+
+
+def test_request_accept_len_variance_respects_log_interval(capsys) -> None:
+    trainer = _trainer(
+        {
+            "request_accept_len_variance_interval_steps": 3,
+        },
+        step=4,
+    )
+
+    batch_size = 2
+    batch = SimpleNamespace(
+        batch={},
+        non_tensor_batch={
+            "_verl_request_mean_accept_len": [1.0, 3.0],
+            "_speco_vllm_request_id": ["req-0", "req-1"],
+        },
+    )
+
+    logged = trainer._speco_log_request_accept_len_variance_from_batch(batch, source="test")
+
+    assert logged is True
+    assert "[speco request accept len]" not in capsys.readouterr().out
+    assert trainer._speco_last_request_accept_len_var == 1.0
+
+
+def test_block_drafter_training_sampler_honors_explicit_hard_labels() -> None:
+    trainer = DrafterBaseTrainer.__new__(DrafterBaseTrainer)
+    trainer.backend = SimpleNamespace(model_type="dspark")
+    trainer.rank = 0
+    trainer.config = SimpleNamespace(
+        rollout=SimpleNamespace(
+            drafter=SimpleNamespace(
+                training={
+                    "dspark_hard_sample_ratio": 0.375,
+                }
+            )
+        )
+    )
+    items = [{"_verl_is_hard": True, "id": f"hard-{index}"} for index in range(16)]
+    items.extend({"_verl_is_hard": False, "id": f"normal-{index}"} for index in range(64))
+
+    selected = trainer._sample_training_items(items, 8, __import__("random").Random(1))
+
+    assert sum(1 for item in selected if item["_verl_is_hard"]) == 3
+
+
+def test_block_drafter_training_sampler_normal_fill_excludes_explicit_hard() -> None:
+    trainer = DrafterBaseTrainer.__new__(DrafterBaseTrainer)
+    trainer.backend = SimpleNamespace(model_type="dspark")
+    trainer.rank = 0
+    trainer.config = SimpleNamespace(
+        rollout=SimpleNamespace(
+            drafter=SimpleNamespace(
+                training={
+                    "dspark_hard_sample_ratio": 0.125,
+                }
+            )
+        )
+    )
+    items = [{"_verl_is_hard": True, "id": f"hard-{index}"} for index in range(32)]
+    items.extend({"_verl_is_hard": False, "id": f"normal-{index}"} for index in range(48))
+
+    selected = trainer._sample_training_items(items, 8, __import__("random").Random(1))
+
+    assert len(selected) == 8
+    assert sum(1 for item in selected if item["_verl_is_hard"]) == 1
 
 
 def test_async_publish_sets_pending_ref_and_waits_before_next_publish() -> None:

--- a/tests/integration/test_vllm_runtime_contract.py
+++ b/tests/integration/test_vllm_runtime_contract.py
@@ -8,13 +8,24 @@ from types import SimpleNamespace
 import pytest
 
 from verl_speco.integration.vllm_runtime import (
+    SPECO_VLLM_REQUEST_STATS_TRACE_HEADER,
     SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX,
     SPECO_VLLM_WORKER_EXTENSION_CLS,
     SpecoVLLMColocateWorkerExtension,
+    _attach_vllm_request_stats_to_trace_headers,
+    _decode_vllm_request_stats_trace_header,
     _describe_vllm_draft_logits,
     _new_vllm_spec_decode_stats,
     _normalize_dflash_target_layer_aliases,
+    _pop_vllm_request_stats_for_ids,
+    _pop_vllm_request_stats_for_rollout_output,
+    _record_vllm_request_acceptance_stats,
     _record_vllm_spec_decode_scheduler_stats,
+    _set_vllm_request_stats_on_output,
+    _stage_vllm_request_stats_for_rollout_output,
+    _vllm_generate_request_id,
+    _vllm_request_accept_stats_to_extra_fields,
+    _vllm_request_accept_stats_to_scalar_extra_fields,
     _validate_vllm_dflash_drafter_config,
     _vllm_ascend_has_dspark_pr11153_k_query_runtime,
     _vllm_spec_decode_stats_to_metrics,
@@ -380,6 +391,115 @@ def test_vllm_acceptance_stats_keep_stable_transport_keys() -> None:
         f"{SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX}_drafts": 4.0,
         f"{SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX}_accepted_tokens": 7.0,
     }
+
+
+def test_vllm_request_acceptance_stats_keep_stable_transport_keys() -> None:
+    scheduler = SimpleNamespace()
+    _record_vllm_request_acceptance_stats(
+        scheduler,
+        request_id="req-1",
+        num_draft_tokens=7,
+        num_accepted_tokens=3,
+        num_invalid_spec_tokens=1,
+    )
+    _record_vllm_request_acceptance_stats(
+        scheduler,
+        request_id="req-1",
+        num_draft_tokens=7,
+        num_accepted_tokens=4,
+        num_invalid_spec_tokens=0,
+    )
+    output = SimpleNamespace(
+        request_id="req-1",
+        _speco_vllm_request_accept_stats=scheduler._speco_vllm_request_accept_stats,
+    )
+
+    assert _vllm_request_accept_stats_to_extra_fields(output) == {
+        "_speco_vllm_request_id": ["req-1"],
+        "_speco_vllm_request_verify_rounds": [2],
+        "_speco_vllm_request_draft_tokens": [14],
+        "_speco_vllm_request_accepted_tokens": [7],
+        "_speco_vllm_request_invalid_spec_tokens": [1],
+        "_speco_vllm_request_completion_index": [0],
+        "_speco_vllm_request_elapsed_sec": [None],
+        "_verl_request_mean_accept_len": [4.5],
+    }
+
+
+def test_vllm_request_acceptance_stats_can_cross_engine_core_trace_headers() -> None:
+    scheduler = SimpleNamespace()
+    _record_vllm_request_acceptance_stats(
+        scheduler,
+        request_id="internal-req-1",
+        num_draft_tokens=7,
+        num_accepted_tokens=6,
+        num_invalid_spec_tokens=0,
+    )
+    summaries, completion_order = _pop_vllm_request_stats_for_ids(scheduler, ["internal-req-1"])
+
+    assert completion_order == ["internal-req-1"]
+    assert scheduler._speco_vllm_request_accept_stats == {}
+
+    engine_core_output = SimpleNamespace(request_id="internal-req-1", trace_headers={"trace": "keep"})
+    _attach_vllm_request_stats_to_trace_headers(engine_core_output, summaries["internal-req-1"])
+
+    assert engine_core_output.trace_headers["trace"] == "keep"
+    decoded = _decode_vllm_request_stats_trace_header(
+        engine_core_output.trace_headers[SPECO_VLLM_REQUEST_STATS_TRACE_HEADER]
+    )
+    assert decoded is not None
+    assert decoded["verify_rounds"] == 1
+    assert decoded["accepted_tokens"] == 6
+
+
+def test_vllm_request_acceptance_stats_extra_fields_use_request_output_id() -> None:
+    output = SimpleNamespace(request_id="external-req-1")
+    summary = {
+        "verify_rounds": 2,
+        "draft_tokens": 14,
+        "accepted_tokens": 8,
+        "invalid_spec_tokens": 1,
+        "completion_index": 3,
+        "elapsed_sec": 0.5,
+    }
+
+    assert _set_vllm_request_stats_on_output(output, {"external-req-1": summary}, ["external-req-1"])
+    assert _vllm_request_accept_stats_to_extra_fields(output) == {
+        "_speco_vllm_request_id": ["external-req-1"],
+        "_speco_vllm_request_verify_rounds": [2],
+        "_speco_vllm_request_draft_tokens": [14],
+        "_speco_vllm_request_accepted_tokens": [8],
+        "_speco_vllm_request_invalid_spec_tokens": [1],
+        "_speco_vllm_request_completion_index": [3],
+        "_speco_vllm_request_elapsed_sec": [0.5],
+        "_verl_request_mean_accept_len": [5.0],
+    }
+
+
+def test_vllm_request_acceptance_stats_can_stage_for_token_output() -> None:
+    summary = {
+        "verify_rounds": 4,
+        "draft_tokens": 28,
+        "accepted_tokens": 12,
+        "invalid_spec_tokens": 0,
+        "completion_index": 5,
+    }
+    _stage_vllm_request_stats_for_rollout_output("server-req-1", {"server-req-1": summary}, ["server-req-1"])
+
+    summaries, completion_order = _pop_vllm_request_stats_for_rollout_output(
+        _vllm_generate_request_id(([], {}, "server-req-1"), {})
+    )
+    output = SimpleNamespace(
+        request_id="server-req-1",
+        _speco_vllm_request_accept_stats=summaries,
+        _speco_vllm_request_completion_order=completion_order,
+    )
+
+    scalar_fields = _vllm_request_accept_stats_to_scalar_extra_fields(output)
+
+    assert scalar_fields["_verl_request_mean_accept_len"] == 4.0
+    assert scalar_fields["_speco_vllm_request_id"] == "server-req-1"
+    assert scalar_fields["_speco_vllm_request_verify_rounds"] == 4
 
 
 def test_trainer_keeps_public_acceptance_metric_name() -> None:

--- a/verl_speco/config/speco_base.yaml
+++ b/verl_speco/config/speco_base.yaml
@@ -56,6 +56,8 @@ actor_rollout_ref:
         old_logprob_hidden_capture_impl: forward_hook
         use_data_buffer: false
         collect_interval_steps: 5
+        # Set to 0 to disable request mean-accept-length variance logging.
+        request_accept_len_variance_interval_steps: 1
         collection_sample_rate: 1.0
         max_collect_samples_per_step_per_replica: 16
         max_collect_tokens_per_step_per_replica: 16384
@@ -115,6 +117,7 @@ actor_rollout_ref:
         dspark_block_size: 7
         dspark_num_anchors: 32
         dspark_loss_decay_gamma: 7.0
+        dspark_hard_candidate_ratio: 0.0
         dspark_hard_sample_ratio: 0.0
         dspark_hidden_size: null
         dspark_num_target_layers: 5

--- a/verl_speco/integration/vllm_runtime.py
+++ b/verl_speco/integration/vllm_runtime.py
@@ -14,6 +14,7 @@ import os
 import sys
 import time
 from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import Any, Iterable
 
 logger = logging.getLogger(__file__)
@@ -25,6 +26,9 @@ SPECO_VLLM_WORKER_EXTENSION_CLS = "verl_speco.integration.vllm_runtime.SpecoVLLM
 SPECO_VLLM_SPEC_DECODE_LOG_INTERVAL_ENV = "VERL_SPECO_VLLM_SPEC_DECODE_LOG_INTERVAL_SECONDS"
 SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX = "_speco_vllm_spec_decode"
 SPECO_VLLM_DRAFT_DIAG_ENV = "VERL_SPECO_VLLM_DRAFT_DIAG"
+SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX = "_speco_vllm_request"
+SPECO_VLLM_REQUEST_STATS_TRACE_HEADER = "x-speco-vllm-request-accept-stats"
+_SPECO_VLLM_REQUEST_OUTPUT_STATS_BY_ID: dict[str, tuple[dict[str, dict[str, Any]], list[str]]] = {}
 
 _VLLM_REPLICA_PATCHED = False
 _VLLM_DFLASH_CONFIG_ALIASES_PATCHED = False
@@ -1095,6 +1099,370 @@ def patch_vllm_spec_decode_acceptance_logging() -> bool:
     return True
 
 
+def _speco_vllm_request_stats_store(scheduler: Any) -> dict[str, dict[str, float]]:
+    stats = getattr(scheduler, "_speco_vllm_request_accept_stats", None)
+    if not isinstance(stats, dict):
+        stats = {}
+        scheduler._speco_vllm_request_accept_stats = stats
+    return stats
+
+
+def _record_vllm_request_acceptance_stats(
+    scheduler: Any,
+    *,
+    request_id: Any,
+    num_draft_tokens: Any,
+    num_accepted_tokens: Any,
+    num_invalid_spec_tokens: Any,
+) -> None:
+    if request_id is None:
+        return
+    draft_tokens = _int_or_zero(num_draft_tokens)
+    accepted_tokens = _int_or_zero(num_accepted_tokens)
+    invalid_tokens = _int_or_zero(num_invalid_spec_tokens)
+    if draft_tokens <= 0 and accepted_tokens <= 0 and invalid_tokens <= 0:
+        return
+    stats = _speco_vllm_request_stats_store(scheduler)
+    key = str(request_id)
+    now = time.perf_counter()
+    item = stats.setdefault(
+        key,
+        {
+            "verify_rounds": 0,
+            "draft_tokens": 0,
+            "accepted_tokens": 0,
+            "invalid_spec_tokens": 0,
+            "started_sec": now,
+            "last_update_sec": now,
+        },
+    )
+    item["verify_rounds"] += 1
+    item["draft_tokens"] += draft_tokens
+    item["accepted_tokens"] += accepted_tokens
+    item["invalid_spec_tokens"] += invalid_tokens
+    item["last_update_sec"] = now
+    scheduler._speco_vllm_request_accept_record_count = _int_or_zero(
+        getattr(scheduler, "_speco_vllm_request_accept_record_count", 0)
+    ) + 1
+
+
+def _request_ids_from_scheduler_output(output: Any) -> list[str]:
+    candidates = []
+    for name in ("finished_req_ids", "finished_request_ids", "finished_requests", "request_ids"):
+        value = getattr(output, name, None)
+        if value is not None:
+            candidates.append(value)
+    request_outputs = getattr(output, "request_outputs", None) or getattr(output, "outputs", None)
+    if isinstance(request_outputs, dict):
+        candidates.append(request_outputs.keys())
+    elif isinstance(request_outputs, (list, tuple)):
+        candidates.append([getattr(item, "request_id", None) for item in request_outputs])
+
+    request_ids: list[str] = []
+    for candidate in candidates:
+        if isinstance(candidate, (str, bytes)):
+            values = [candidate]
+        else:
+            try:
+                values = list(candidate)
+            except TypeError:
+                values = [candidate]
+        for value in values:
+            if value is not None:
+                request_ids.append(str(value))
+    return list(dict.fromkeys(request_ids))
+
+
+def _pop_vllm_request_stats_for_ids(
+    scheduler: Any,
+    request_ids: Iterable[Any],
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    stats = getattr(scheduler, "_speco_vllm_request_accept_stats", None)
+    if not isinstance(stats, dict) or not stats:
+        return {}, []
+    summaries: dict[str, dict[str, Any]] = {}
+    completion_order: list[str] = []
+    completion_counter = _int_or_zero(getattr(scheduler, "_speco_vllm_request_completion_counter", 0))
+    for request_id in request_ids:
+        request_id = str(request_id)
+        item = stats.pop(request_id, None)
+        if item is None:
+            continue
+        item = dict(item)
+        item["completion_index"] = completion_counter
+        completed_sec = time.perf_counter()
+        item["completed_sec"] = completed_sec
+        item["completed_time"] = time.time()
+        started_sec = item.get("started_sec")
+        if isinstance(started_sec, (int, float)):
+            item["elapsed_sec"] = max(0.0, completed_sec - float(started_sec))
+        completion_counter += 1
+        completion_order.append(request_id)
+        summaries[request_id] = dict(item)
+    if summaries:
+        scheduler._speco_vllm_request_completion_counter = completion_counter
+    return summaries, completion_order
+
+
+def _set_vllm_request_stats_on_output(
+    output: Any,
+    summaries: dict[str, dict[str, Any]],
+    completion_order: list[str],
+) -> bool:
+    if not summaries:
+        return False
+    try:
+        setattr(output, "_speco_vllm_request_accept_stats", summaries)
+        setattr(output, "_speco_vllm_request_completion_order", completion_order)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def _stage_vllm_request_stats_for_rollout_output(
+    request_id: Any,
+    summaries: dict[str, dict[str, Any]],
+    completion_order: list[str],
+) -> None:
+    if request_id is None or not summaries:
+        return
+    _SPECO_VLLM_REQUEST_OUTPUT_STATS_BY_ID[str(request_id)] = (summaries, completion_order)
+
+
+def _pop_vllm_request_stats_for_rollout_output(
+    request_id: Any,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    if request_id is None:
+        return {}, []
+    return _SPECO_VLLM_REQUEST_OUTPUT_STATS_BY_ID.pop(str(request_id), ({}, []))
+
+
+def _vllm_generate_request_id(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    if "request_id" in kwargs:
+        return kwargs["request_id"]
+    if len(args) >= 3:
+        return args[2]
+    return None
+
+
+def _encode_vllm_request_stats_trace_header(summary: dict[str, Any]) -> str:
+    return json.dumps(summary, ensure_ascii=True, separators=(",", ":"))
+
+
+def _decode_vllm_request_stats_trace_header(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        decoded = json.loads(value)
+    except Exception:  # noqa: BLE001
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _attach_vllm_request_stats_to_trace_headers(engine_core_output: Any, summary: dict[str, Any]) -> None:
+    if not summary:
+        return
+    trace_headers = getattr(engine_core_output, "trace_headers", None)
+    try:
+        headers = dict(trace_headers) if trace_headers is not None else {}
+        headers[SPECO_VLLM_REQUEST_STATS_TRACE_HEADER] = _encode_vllm_request_stats_trace_header(summary)
+        setattr(engine_core_output, "trace_headers", headers)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Failed to attach SPECO request stats to EngineCoreOutput trace headers: %s", exc)
+
+
+def _attach_vllm_request_stats_to_output(scheduler: Any, output: Any) -> None:
+    stats = getattr(scheduler, "_speco_vllm_request_accept_stats", None)
+    if not isinstance(stats, dict) or not stats:
+        return
+    request_ids = _request_ids_from_scheduler_output(output)
+    if not request_ids:
+        return
+    summaries, completion_order = _pop_vllm_request_stats_for_ids(scheduler, request_ids)
+    if not summaries:
+        return
+    _set_vllm_request_stats_on_output(output, summaries, completion_order)
+
+
+def patch_vllm_request_acceptance_stats() -> bool:
+    """Carry request-level speculative acceptance summaries to rollout outputs.
+
+    vLLM V1 emits final request data through EngineCoreOutput -> RequestOutput,
+    while SchedulerOutput.finished_req_ids is only a cache-release signal in
+    newer commits. Record counters in the scheduler, transport them through an
+    internal trace header on final EngineCoreOutput objects, then restore them
+    on the RequestOutput consumed by verl.
+    """
+
+    try:
+        from vllm.v1.core.sched.scheduler import Scheduler
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Unable to install vLLM request acceptance stats patch: %s", exc)
+        return False
+
+    original_make_stats = getattr(Scheduler, "make_spec_decoding_stats", None)
+    if callable(original_make_stats) and not getattr(original_make_stats, "_speco_request_acceptance_stats", False):
+
+        def patched_make_spec_decoding_stats(
+            self,
+            spec_decoding_stats,
+            num_draft_tokens,
+            num_accepted_tokens,
+            num_invalid_spec_tokens,
+            request_id,
+        ):
+            result = original_make_stats(
+                self,
+                spec_decoding_stats,
+                num_draft_tokens,
+                num_accepted_tokens,
+                num_invalid_spec_tokens,
+                request_id,
+            )
+            try:
+                _record_vllm_request_acceptance_stats(
+                    self,
+                    request_id=request_id,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted_tokens,
+                    num_invalid_spec_tokens=num_invalid_spec_tokens,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed to record vLLM request acceptance stats: %s", exc)
+            return result
+
+        patched_make_spec_decoding_stats._speco_request_acceptance_stats = True
+        patched_make_spec_decoding_stats._speco_original_make_spec_decoding_stats = original_make_stats
+        Scheduler.make_spec_decoding_stats = patched_make_spec_decoding_stats
+
+    original_update_from_output = getattr(Scheduler, "update_from_output", None)
+    if callable(original_update_from_output) and not getattr(
+        original_update_from_output,
+        "_speco_request_acceptance_stats",
+        False,
+    ):
+
+        def patched_update_from_output(self, scheduler_output, model_runner_output):
+            engine_core_outputs = original_update_from_output(self, scheduler_output, model_runner_output)
+            try:
+                finished_outputs = []
+                for client_outputs in engine_core_outputs.values():
+                    for engine_core_output in getattr(client_outputs, "outputs", None) or ():
+                        is_finished = bool(getattr(engine_core_output, "finished", False))
+                        if not is_finished and getattr(engine_core_output, "finish_reason", None) is None:
+                            continue
+                        request_id = getattr(engine_core_output, "request_id", None)
+                        if request_id is not None:
+                            finished_outputs.append((str(request_id), engine_core_output))
+                if finished_outputs:
+                    summaries, _ = _pop_vllm_request_stats_for_ids(
+                        self,
+                        [request_id for request_id, _ in finished_outputs],
+                    )
+                    for request_id, engine_core_output in finished_outputs:
+                        summary = summaries.get(request_id)
+                        if summary is not None:
+                            _attach_vllm_request_stats_to_trace_headers(engine_core_output, summary)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed to attach vLLM request stats to EngineCoreOutputs: %s", exc)
+            return engine_core_outputs
+
+        patched_update_from_output._speco_request_acceptance_stats = True
+        patched_update_from_output._speco_original_update_from_output = original_update_from_output
+        Scheduler.update_from_output = patched_update_from_output
+
+    original_schedule = getattr(Scheduler, "schedule", None)
+    if callable(original_schedule) and not getattr(original_schedule, "_speco_request_acceptance_stats", False):
+
+        def patched_schedule(self, *args, **kwargs):
+            output = original_schedule(self, *args, **kwargs)
+            try:
+                _attach_vllm_request_stats_to_output(self, output)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed to attach vLLM request acceptance stats: %s", exc)
+            return output
+
+        patched_schedule._speco_request_acceptance_stats = True
+        patched_schedule._speco_original_schedule = original_schedule
+        Scheduler.schedule = patched_schedule
+
+    try:
+        from vllm.v1.engine.output_processor import OutputProcessor, RequestState
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Unable to install vLLM output processor request stats patch: %s", exc)
+        return True
+
+    original_process_outputs = getattr(OutputProcessor, "process_outputs", None)
+    if callable(original_process_outputs) and not getattr(
+        original_process_outputs,
+        "_speco_request_acceptance_stats",
+        False,
+    ):
+
+        def patched_process_outputs(self, engine_core_outputs, *args, **kwargs):
+            try:
+                for engine_core_output in engine_core_outputs:
+                    request_id = getattr(engine_core_output, "request_id", None)
+                    req_state = getattr(self, "request_states", {}).get(request_id)
+                    if req_state is None:
+                        continue
+                    trace_headers = getattr(engine_core_output, "trace_headers", None)
+                    if not isinstance(trace_headers, dict):
+                        try:
+                            trace_headers = dict(trace_headers) if trace_headers is not None else {}
+                        except Exception:  # noqa: BLE001
+                            trace_headers = {}
+                    summary = _decode_vllm_request_stats_trace_header(
+                        trace_headers.get(SPECO_VLLM_REQUEST_STATS_TRACE_HEADER)
+                    )
+                    if summary:
+                        setattr(req_state, "_speco_vllm_request_accept_summary", summary)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Failed to stage vLLM request stats on RequestState: %s", exc)
+            return original_process_outputs(self, engine_core_outputs, *args, **kwargs)
+
+        patched_process_outputs._speco_request_acceptance_stats = True
+        patched_process_outputs._speco_original_process_outputs = original_process_outputs
+        OutputProcessor.process_outputs = patched_process_outputs
+
+    original_make_request_output = getattr(RequestState, "make_request_output", None)
+    if callable(original_make_request_output) and not getattr(
+        original_make_request_output,
+        "_speco_request_acceptance_stats",
+        False,
+    ):
+
+        def patched_make_request_output(self, *args, **kwargs):
+            request_output = original_make_request_output(self, *args, **kwargs)
+            if request_output is None:
+                return request_output
+            summary = getattr(self, "_speco_vllm_request_accept_summary", None)
+            if not isinstance(summary, dict) or not summary:
+                return request_output
+            request_id = getattr(request_output, "request_id", None) or getattr(
+                self,
+                "external_req_id",
+                None,
+            )
+            if request_id is not None:
+                request_id = str(request_id)
+                summaries = {request_id: summary}
+                completion_order = [request_id]
+                _set_vllm_request_stats_on_output(request_output, summaries, completion_order)
+                _stage_vllm_request_stats_for_rollout_output(request_id, summaries, completion_order)
+                try:
+                    delattr(self, "_speco_vllm_request_accept_summary")
+                except Exception:  # noqa: BLE001
+                    pass
+            return request_output
+
+        patched_make_request_output._speco_request_acceptance_stats = True
+        patched_make_request_output._speco_original_make_request_output = original_make_request_output
+        RequestState.make_request_output = patched_make_request_output
+
+    return True
+
+
 def patch_vllm_dflash_config_aliases() -> bool:
     """Let vLLM 0.23 consume SPECO DFlash top-level target layer ids."""
 
@@ -1165,6 +1533,7 @@ def _speco_vllm_run_engine_core_with_acceptance_logging(*args, **kwargs):
     patch_vllm_dspark_registry_aliases()
     patch_vllm_dspark_runtime()
     patch_vllm_spec_decode_acceptance_logging()
+    patch_vllm_request_acceptance_stats()
     patch_vllm_worker_proc_entrypoint()
 
     from vllm.v1.engine.core import EngineCoreProc
@@ -1202,6 +1571,7 @@ def _speco_vllm_worker_main_with_runtime_observability(*args, **kwargs):
     patch_vllm_dspark_registry_aliases()
     patch_vllm_dspark_runtime()
     patch_vllm_spec_decode_acceptance_logging()
+    patch_vllm_request_acceptance_stats()
 
     original = getattr(_speco_vllm_worker_main_with_runtime_observability, "_speco_original_worker_main", None)
     if not callable(original):
@@ -1254,12 +1624,14 @@ def install_vllm_runtime_observability() -> bool:
     dspark_registry_patched = patch_vllm_dspark_registry_aliases()
     dspark_runtime_patched = patch_vllm_dspark_runtime()
     acceptance_patched = install_vllm_spec_decode_acceptance_logging()
+    request_acceptance_patched = patch_vllm_request_acceptance_stats()
     worker_proc_patched = patch_vllm_worker_proc_entrypoint()
     return (
         dflash_config_patched
         or dspark_registry_patched
         or dspark_runtime_patched
         or acceptance_patched
+        or request_acceptance_patched
         or worker_proc_patched
     )
 
@@ -1290,6 +1662,63 @@ def _vllm_spec_decode_stats_to_metrics(stats: dict[str, float]) -> dict[str, flo
         f"{SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX}_drafts": drafts,
         f"{SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX}_accepted_tokens": accepted_tokens,
     }
+
+
+def _vllm_request_accept_stats_to_extra_fields(output: Any) -> dict[str, Any]:
+    summaries = getattr(output, "_speco_vllm_request_accept_stats", None)
+    if not isinstance(summaries, dict) or not summaries:
+        return {}
+    completion_order = getattr(output, "_speco_vllm_request_completion_order", None)
+    output_request_id = getattr(output, "request_id", None)
+    if output_request_id is not None and str(output_request_id) in summaries:
+        ordered_ids = [str(output_request_id)]
+    elif isinstance(completion_order, (list, tuple)):
+        ordered_ids = [str(request_id) for request_id in completion_order if str(request_id) in summaries]
+        ordered_ids.extend(str(request_id) for request_id in summaries if str(request_id) not in set(ordered_ids))
+    else:
+        ordered_ids = list(summaries)
+    verify_rounds = []
+    draft_tokens = []
+    accepted_tokens = []
+    invalid_tokens = []
+    completion_indices = []
+    mean_accept_len = []
+    elapsed_sec = []
+    for request_id in ordered_ids:
+        item = summaries.get(request_id) or {}
+        rounds = _int_or_zero(item.get("verify_rounds", 0))
+        accepted = _int_or_zero(item.get("accepted_tokens", 0))
+        request_mean_accept_len = 1.0 + accepted / rounds if rounds > 0 else None
+        elapsed_value = item.get("elapsed_sec")
+        request_elapsed_sec = float(elapsed_value) if isinstance(elapsed_value, (int, float)) else None
+        verify_rounds.append(rounds)
+        draft_tokens.append(_int_or_zero(item.get("draft_tokens", 0)))
+        accepted_tokens.append(accepted)
+        invalid_tokens.append(_int_or_zero(item.get("invalid_spec_tokens", 0)))
+        completion_indices.append(_int_or_zero(item.get("completion_index", 0)))
+        mean_accept_len.append(request_mean_accept_len)
+        elapsed_sec.append(request_elapsed_sec)
+    return {
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_id": ordered_ids,
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_verify_rounds": verify_rounds,
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_draft_tokens": draft_tokens,
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_accepted_tokens": accepted_tokens,
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_invalid_spec_tokens": invalid_tokens,
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_completion_index": completion_indices,
+        f"{SPECO_VLLM_REQUEST_STATS_EXTRA_PREFIX}_elapsed_sec": elapsed_sec,
+        "_verl_request_mean_accept_len": mean_accept_len,
+    }
+
+
+def _vllm_request_accept_stats_to_scalar_extra_fields(output: Any) -> dict[str, Any]:
+    fields = _vllm_request_accept_stats_to_extra_fields(output)
+    scalar_fields = {}
+    for key, value in fields.items():
+        if isinstance(value, (list, tuple)):
+            scalar_fields[key] = value[0] if value else None
+        else:
+            scalar_fields[key] = value
+    return scalar_fields
 
 
 def _build_speco_vllm_stat_logger(server: Any):
@@ -1349,6 +1778,9 @@ class _SpecoVLLMHttpServerMixin:
         stats = self._speco_pop_vllm_spec_decode_stats()
         extra_fields.update(_vllm_spec_decode_stats_to_metrics(stats))
 
+    def _speco_add_vllm_request_accept_extra_fields(self, output: Any, extra_fields: dict[str, Any]) -> None:
+        extra_fields.update(_vllm_request_accept_stats_to_extra_fields(output))
+
     async def launch_server(self, *args, **kwargs):
         self._speco_vllm_spec_decode_pending_stats = _new_vllm_spec_decode_stats()
         install_vllm_runtime_observability()
@@ -1387,10 +1819,20 @@ class _SpecoVLLMHttpServerMixin:
             AsyncLLM.from_vllm_config = original_from_vllm_config_attr
 
     async def generate(self, *args, **kwargs):
+        request_id = _vllm_generate_request_id(args, kwargs)
         output = await super().generate(*args, **kwargs)
         extra_fields = getattr(output, "extra_fields", None)
         if isinstance(extra_fields, dict):
             self._speco_add_vllm_spec_decode_extra_fields(extra_fields)
+            self._speco_add_vllm_request_accept_extra_fields(output, extra_fields)
+            summaries, completion_order = _pop_vllm_request_stats_for_rollout_output(request_id)
+            if summaries:
+                proxy_output = SimpleNamespace(
+                    request_id=request_id,
+                    _speco_vllm_request_accept_stats=summaries,
+                    _speco_vllm_request_completion_order=completion_order,
+                )
+                extra_fields.update(_vllm_request_accept_stats_to_scalar_extra_fields(proxy_output))
         return output
 
 

--- a/verl_speco/trainer/base_trainer.py
+++ b/verl_speco/trainer/base_trainer.py
@@ -256,6 +256,23 @@ def _batch_item_float(value: Any, index: int = 0) -> float | None:
         return None
 
 
+def _batch_item_value(value: Any, index: int = 0) -> Any:
+    if value is None:
+        return None
+    if torch.is_tensor(value):
+        if value.numel() == 0:
+            return None
+        flat = value.detach().view(-1).cpu()
+        index = min(max(int(index), 0), flat.numel() - 1)
+        return flat[index].item()
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        index = min(max(int(index), 0), len(value) - 1)
+        return value[index]
+    return value
+
+
 def _tensor_sum_int(tensor: torch.Tensor) -> int:
     return int(tensor.detach().float().sum().cpu().item())
 
@@ -2265,6 +2282,21 @@ class DrafterBaseTrainer:
                 "_verl_response_len": response_len if cpu_responses is not None else None,
                 "_verl_accept_len": accept_len,
                 "_verl_accept_rate": accept_rate,
+                "_verl_request_mean_accept_len": _batch_item_float(
+                    batch.get("_verl_request_mean_accept_len"),
+                    i,
+                ),
+                "_speco_vllm_request_id": _batch_item_value(batch.get("_speco_vllm_request_id"), i),
+                "_speco_vllm_request_elapsed_sec": _batch_item_float(
+                    batch.get("_speco_vllm_request_elapsed_sec"),
+                    i,
+                ),
+                "_verl_is_hard": bool(_batch_item_int(batch.get("_verl_is_hard"), i) or 0),
+                "_verl_hard_score": _batch_item_float(batch.get("_verl_hard_score"), i),
+                "_speco_vllm_request_completion_index": _batch_item_int(
+                    batch.get("_speco_vllm_request_completion_index"),
+                    i,
+                ),
                 "_verl_input_seq_length": input_seq_length,
                 "hidden_lm_head_fingerprint": batch.get("hidden_lm_head_fingerprint"),
                 "hidden_last_hidden_logprob_check": batch.get("hidden_last_hidden_logprob_check"),
@@ -2502,6 +2534,7 @@ class DrafterBaseTrainer:
         explicit_score = self._item_float(
             item,
             (
+                "_verl_hard_score",
                 "_verl_dflash_hard_score",
                 "dflash_hard_score",
                 "_verl_sample_loss",
@@ -2530,6 +2563,19 @@ class DrafterBaseTrainer:
 
         return None
 
+    @staticmethod
+    def _explicit_hard_label(item: dict[str, Any]) -> Optional[bool]:
+        if "_verl_is_hard" not in item:
+            return None
+        value = item.get("_verl_is_hard")
+        if torch.is_tensor(value):
+            if value.numel() != 1:
+                return None
+            value = value.detach().cpu().item()
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+        return bool(value)
+
     def _sample_training_items(
         self,
         available_data: list[dict[str, Any]],
@@ -2544,6 +2590,27 @@ class DrafterBaseTrainer:
             return rng.sample(available_data, batch_size)
 
         hard_count = min(batch_size, max(0, round(batch_size * hard_ratio)))
+        explicit_hard = [item for item in available_data if self._explicit_hard_label(item) is True]
+        if explicit_hard:
+            selected = rng.sample(explicit_hard, min(hard_count, len(explicit_hard)))
+            if len(selected) < hard_count:
+                logger.warning(
+                    "[Rank %s] DSpark hard sample quota underfilled: selected %s/%s hard samples",
+                    self.rank,
+                    len(selected),
+                    hard_count,
+                )
+            selected_ids = {id(item) for item in selected}
+            remaining = [
+                item
+                for item in available_data
+                if id(item) not in selected_ids and self._explicit_hard_label(item) is not True
+            ]
+            random_count = batch_size - len(selected)
+            if random_count > 0:
+                selected.extend(rng.sample(remaining, min(random_count, len(remaining))))
+            return selected
+
         scored: list[tuple[float, float, dict[str, Any]]] = []
         for item in available_data:
             score = self._dflash_hard_sample_score(item)

--- a/verl_speco/trainer/speco_ray_trainer.py
+++ b/verl_speco/trainer/speco_ray_trainer.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import logging
+import math
 import os
 import time
 from contextlib import contextmanager
@@ -64,11 +65,35 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 SPECO_VLLM_SPEC_DECODE_MEAN_ACCEPTANCE_METRIC = "drafter/spec_decode/mean_acceptance_length"
 _SPECO_VLLM_SPEC_DECODE_DRAFTS_KEY = "_speco_vllm_spec_decode_drafts"
 _SPECO_VLLM_SPEC_DECODE_ACCEPTED_TOKENS_KEY = "_speco_vllm_spec_decode_accepted_tokens"
+_SPECO_VLLM_REQUEST_VERIFY_ROUNDS_KEY = "_speco_vllm_request_verify_rounds"
+_SPECO_VLLM_REQUEST_ACCEPTED_TOKENS_KEY = "_speco_vllm_request_accepted_tokens"
+_SPECO_VLLM_REQUEST_DRAFT_TOKENS_KEY = "_speco_vllm_request_draft_tokens"
+_SPECO_VLLM_REQUEST_INVALID_TOKENS_KEY = "_speco_vllm_request_invalid_spec_tokens"
+_SPECO_VLLM_REQUEST_COMPLETION_INDEX_KEY = "_speco_vllm_request_completion_index"
+_SPECO_VLLM_REQUEST_ELAPSED_SEC_KEY = "_speco_vllm_request_elapsed_sec"
+_SPECO_VLLM_REQUEST_MEAN_ACCEPT_LEN_KEY = "_verl_request_mean_accept_len"
+_SPECO_VLLM_REQUEST_IS_HARD_KEY = "_verl_is_hard"
+_SPECO_VLLM_REQUEST_HARD_SCORE_KEY = "_verl_hard_score"
+_SPECO_VLLM_REQUEST_ID_KEY = "_speco_vllm_request_id"
 _SPECO_DRAFTER_TIMING_DEDUCTED_KEY = "_speco_drafter_timing_deducted_from_update_actor"
+_SPECO_REQUEST_ACCEPT_LEN_HIST_LOG_PATH_ENV = "VERL_SPECO_REQUEST_ACCEPT_LEN_HIST_LOG_PATH"
+_SPECO_REQUEST_ACCEPT_LEN_HIST_PRINT_ENV = "VERL_SPECO_REQUEST_ACCEPT_LEN_HIST_PRINT"
+_SPECO_REQUEST_ACCEPT_LEN_HIST_BIN_WIDTH_ENV = "VERL_SPECO_REQUEST_ACCEPT_LEN_HIST_BIN_WIDTH"
 _DRAFTER_TARGET_SYNC_MESH = "drafter_target_sync"
 
 _DRAFTER_CHECKPOINT_PATH_PLACEHOLDERS = {None, "", "null", "None", "/path/to/drafter/checkpoint"}
-_POLICY_MODEL_NON_TENSOR_KEYS = {"multi_modal_inputs", "pad_token_id"}
+_POLICY_MODEL_NON_TENSOR_KEYS = {
+    "multi_modal_inputs",
+    "pad_token_id",
+    "_speco_vllm_request_id",
+    "_speco_vllm_request_verify_rounds",
+    "_speco_vllm_request_accepted_tokens",
+    "_speco_vllm_request_draft_tokens",
+    "_speco_vllm_request_invalid_spec_tokens",
+    "_speco_vllm_request_completion_index",
+    "_speco_vllm_request_elapsed_sec",
+    "_verl_request_mean_accept_len",
+}
 
 
 def _select_policy_model_batch(batch: DataProto) -> DataProto:
@@ -201,6 +226,135 @@ def _speco_float_values(values: Any) -> list[float]:
     return normalized
 
 
+def _speco_sequence_values(value: Any, size: int) -> list[Any]:
+    if value is None:
+        return [None for _ in range(size)]
+    if torch.is_tensor(value):
+        value = value.detach().cpu().tolist()
+    elif hasattr(value, "tolist") and not isinstance(value, (str, bytes, bytearray)):
+        value = value.tolist()
+    if not isinstance(value, (list, tuple)):
+        value = [value]
+    return [value[index] if index < len(value) else None for index in range(size)]
+
+
+def _speco_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if torch.is_tensor(value):
+        if value.numel() != 1:
+            return None
+        value = value.detach().cpu().item()
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _speco_diag_enabled(name: str, default: str = "1") -> bool:
+    value = os.getenv(name, default)
+    if value is None:
+        return False
+    return str(value).strip().lower() not in {"0", "false", "off", "no", "n", ""}
+
+
+def _speco_append_jsonl(path: str | None, payload: dict[str, Any]) -> None:
+    _speco_append_jsonl_batch(path, [payload])
+
+
+def _speco_append_jsonl_batch(path: str | None, payloads: list[dict[str, Any]]) -> None:
+    if not path:
+        return
+    if not payloads:
+        return
+    try:
+        directory = os.path.dirname(path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as file:
+            file.write(
+                "".join(json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n" for payload in payloads)
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Failed to append SPECO diagnostic log %s: %s", path, exc)
+
+
+def _speco_accept_len_quantile(sorted_values: list[float], q: float) -> float | None:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = (len(sorted_values) - 1) * q
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+    weight = position - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+
+def _speco_accept_len_hist_bin_width() -> float:
+    value = _speco_optional_float(os.getenv(_SPECO_REQUEST_ACCEPT_LEN_HIST_BIN_WIDTH_ENV, "0.1"))
+    return value if value is not None and value > 0 else 0.1
+
+
+def _speco_accept_len_histogram(values: list[float], *, bin_width: float) -> list[dict[str, Any]]:
+    counts: dict[int, int] = {}
+    for value in values:
+        index = math.floor(value / bin_width)
+        counts[index] = counts.get(index, 0) + 1
+    return [
+        {
+            "left": round(index * bin_width, 6),
+            "right": round((index + 1) * bin_width, 6),
+            "center": round((index + 0.5) * bin_width, 6),
+            "count": count,
+        }
+        for index, count in sorted(counts.items())
+    ]
+
+
+def _speco_request_accept_len_step_payload(
+    *,
+    step: int,
+    source: str,
+    records: list[dict[str, Any]],
+    accept_len_var: float,
+) -> dict[str, Any] | None:
+    values = [
+        float(record["mean_accept_len"])
+        for record in records
+        if _speco_optional_float(record.get("mean_accept_len")) is not None
+    ]
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    bin_width = _speco_accept_len_hist_bin_width()
+    mean_accept_len = sum(values) / len(values)
+    return {
+        "step": int(step),
+        "source": source,
+        "count": len(values),
+        "accept_lens": [round(value, 6) for value in values],
+        "summary": {
+            "min": round(sorted_values[0], 6),
+            "max": round(sorted_values[-1], 6),
+            "mean": round(mean_accept_len, 6),
+            "p50": round(float(_speco_accept_len_quantile(sorted_values, 0.50)), 6),
+            "p90": round(float(_speco_accept_len_quantile(sorted_values, 0.90)), 6),
+            "p95": round(float(_speco_accept_len_quantile(sorted_values, 0.95)), 6),
+            "var": round(float(accept_len_var), 6),
+        },
+        "histogram": {
+            "bin_width": round(bin_width, 6),
+            "x": "mean_accept_len",
+            "y": "request_count",
+            "bins": _speco_accept_len_histogram(values, bin_width=bin_width),
+        },
+    }
+
+
 def _speco_vllm_spec_decode_stats_from_batch(batch: Any) -> dict[str, float]:
     non_tensor_batch = getattr(batch, "non_tensor_batch", None)
     if not isinstance(non_tensor_batch, dict):
@@ -324,6 +478,7 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         self._speco_last_oldlogprob_collect_rpc_elapsed_sec = 0.0
         self._speco_last_oldlogprob_total_elapsed_sec = 0.0
         self._speco_last_collect_interval_matched = 0
+        self._speco_pending_request_accept_len_payloads = []
 
     def attach_speco_worker_group(self, worker_group):
         self.drafter_wg = worker_group
@@ -683,6 +838,11 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         training_cfg = self._speco_drafter_training_config()
         return speco_step_matches_interval(self.global_steps, training_cfg.get("training_interval_steps", 1))
 
+    def _speco_should_log_request_accept_len_variance(self) -> bool:
+        training_cfg = self._speco_drafter_training_config()
+        interval_steps = training_cfg.get("request_accept_len_variance_interval_steps", 1)
+        return speco_step_matches_interval(self.global_steps, interval_steps)
+
     def _speco_drafter_training_mode(self) -> str:
         training_cfg = self._speco_drafter_training_config()
         return str(training_cfg.get("mode", "online") or "online").strip().lower()
@@ -935,6 +1095,205 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         digest = hashlib.blake2b(key.encode(), digest_size=8).digest()
         return int.from_bytes(digest, byteorder="big", signed=False) % (inclusive_max + 1)
 
+    def _speco_request_accept_lengths(self, batch: DataProto, batch_size: int) -> list[float | None]:
+        non_tensor_batch = getattr(batch, "non_tensor_batch", None)
+        if not isinstance(non_tensor_batch, dict):
+            return [None for _ in range(batch_size)]
+
+        explicit = _speco_sequence_values(
+            non_tensor_batch.get(_SPECO_VLLM_REQUEST_MEAN_ACCEPT_LEN_KEY),
+            batch_size,
+        )
+        result = [_speco_optional_float(value) for value in explicit]
+        if any(value is not None for value in result):
+            return result
+
+        rounds = _speco_sequence_values(non_tensor_batch.get(_SPECO_VLLM_REQUEST_VERIFY_ROUNDS_KEY), batch_size)
+        accepted = _speco_sequence_values(non_tensor_batch.get(_SPECO_VLLM_REQUEST_ACCEPTED_TOKENS_KEY), batch_size)
+        for index, (round_value, accepted_value) in enumerate(zip(rounds, accepted, strict=False)):
+            verify_rounds = _speco_optional_float(round_value)
+            accepted_tokens = _speco_optional_float(accepted_value)
+            if verify_rounds is None or verify_rounds <= 0 or accepted_tokens is None:
+                continue
+            result[index] = 1.0 + accepted_tokens / verify_rounds
+        return result
+
+    def _speco_request_ids(self, batch: DataProto, batch_size: int, *, require: bool = False) -> list[str]:
+        non_tensor_batch = getattr(batch, "non_tensor_batch", None)
+        if not isinstance(non_tensor_batch, dict):
+            if require:
+                raise RuntimeError("SPECO request acceptance stats require a non-tensor request id field")
+            return [str(index) for index in range(batch_size)]
+        if require and _SPECO_VLLM_REQUEST_ID_KEY not in non_tensor_batch:
+            raise RuntimeError(f"SPECO request acceptance stats missing {_SPECO_VLLM_REQUEST_ID_KEY}")
+        request_ids = _speco_sequence_values(non_tensor_batch.get(_SPECO_VLLM_REQUEST_ID_KEY), batch_size)
+        if require and any(value is None for value in request_ids):
+            raise RuntimeError("SPECO request acceptance stats contain a missing request id")
+        if require and len({str(value) for value in request_ids}) != batch_size:
+            raise RuntimeError("SPECO request acceptance stats contain duplicate request ids")
+        return [str(value) if value is not None else str(index) for index, value in enumerate(request_ids)]
+
+    def _speco_request_completion_indices(self, batch: DataProto, batch_size: int) -> list[int | None]:
+        non_tensor_batch = getattr(batch, "non_tensor_batch", None)
+        if not isinstance(non_tensor_batch, dict):
+            return [None for _ in range(batch_size)]
+        values = _speco_sequence_values(
+            non_tensor_batch.get(_SPECO_VLLM_REQUEST_COMPLETION_INDEX_KEY),
+            batch_size,
+        )
+        indices = []
+        for value in values:
+            parsed = _speco_optional_float(value)
+            indices.append(int(parsed) if parsed is not None else None)
+        return indices
+
+    def _speco_request_elapsed_secs(self, batch: DataProto, batch_size: int) -> list[float | None]:
+        non_tensor_batch = getattr(batch, "non_tensor_batch", None)
+        if not isinstance(non_tensor_batch, dict):
+            return [None for _ in range(batch_size)]
+        values = _speco_sequence_values(
+            non_tensor_batch.get(_SPECO_VLLM_REQUEST_ELAPSED_SEC_KEY),
+            batch_size,
+        )
+        return [_speco_optional_float(value) for value in values]
+
+    @staticmethod
+    def _speco_batch_size_from_request_stats(batch: DataProto) -> int:
+        non_tensor_batch = getattr(batch, "non_tensor_batch", None)
+        if not isinstance(non_tensor_batch, dict):
+            return 0
+        for key in (
+            _SPECO_VLLM_REQUEST_MEAN_ACCEPT_LEN_KEY,
+            _SPECO_VLLM_REQUEST_VERIFY_ROUNDS_KEY,
+            _SPECO_VLLM_REQUEST_ACCEPTED_TOKENS_KEY,
+            _SPECO_VLLM_REQUEST_ID_KEY,
+        ):
+            values = non_tensor_batch.get(key)
+            if values is None or isinstance(values, (str, bytes)):
+                continue
+            try:
+                return len(values)
+            except TypeError:
+                tolist = getattr(values, "tolist", None)
+                if callable(tolist):
+                    try:
+                        return len(tolist())
+                    except TypeError:
+                        continue
+        return 0
+
+    def _speco_log_request_accept_len_variance_from_batch(self, batch: DataProto, *, source: str) -> bool:
+        batch_size = self._speco_batch_size_from_request_stats(batch)
+        if batch_size <= 0:
+            return False
+
+        request_accept_lens = self._speco_request_accept_lengths(batch, batch_size)
+        request_ids = self._speco_request_ids(batch, batch_size, require=True)
+        request_completion_indices = self._speco_request_completion_indices(batch, batch_size)
+        request_elapsed_secs = self._speco_request_elapsed_secs(batch, batch_size)
+        candidates = [
+            {
+                "batch_idx": batch_idx,
+                "request_id": request_ids[batch_idx],
+                "mean_accept_len": request_accept_lens[batch_idx],
+                "completion_index": request_completion_indices[batch_idx],
+                "elapsed_sec": request_elapsed_secs[batch_idx],
+            }
+            for batch_idx in range(batch_size)
+        ]
+        marker = torch.zeros(batch_size, dtype=torch.bool)
+        records, accept_len_var = self._speco_log_request_accept_lens(
+            candidates=candidates,
+            is_hard=marker,
+            collect_mask=marker,
+        )
+        payload = _speco_request_accept_len_step_payload(
+            step=self.global_steps,
+            source=source,
+            records=records,
+            accept_len_var=accept_len_var,
+        )
+        if payload:
+            self._speco_pending_request_accept_len_payloads.append(payload)
+        return bool(records)
+
+    def _speco_log_request_accept_lens(
+        self,
+        *,
+        candidates: list[dict[str, Any]],
+        is_hard: torch.Tensor,
+        collect_mask: torch.Tensor,
+    ) -> tuple[list[dict[str, Any]], float]:
+        records = []
+        for candidate in candidates:
+            mean_accept_len = candidate.get("mean_accept_len")
+            if mean_accept_len is None:
+                continue
+            batch_idx = int(candidate["batch_idx"])
+            records.append(
+                {
+                    "completion_index": candidate.get("completion_index"),
+                    "batch_idx": batch_idx,
+                    "request_id": str(candidate.get("request_id")),
+                    "mean_accept_len": round(float(mean_accept_len), 6),
+                    "elapsed_sec": (
+                        round(float(candidate["elapsed_sec"]), 6)
+                        if candidate.get("elapsed_sec") is not None
+                        else None
+                    ),
+                    "is_hard": bool(is_hard[batch_idx].item()),
+                    "collected": bool(collect_mask[batch_idx].item()),
+                }
+            )
+        # Keep completion-order sorting local to diagnostics; training uses the
+        # original batch-indexed request arrays below.
+        records.sort(
+            key=lambda item: (
+                item["completion_index"] is None,
+                item["completion_index"] if item["completion_index"] is not None else item["batch_idx"],
+                item["batch_idx"],
+            )
+        )
+        accept_lens = [float(record["mean_accept_len"]) for record in records]
+        if accept_lens:
+            mean_accept_len = sum(accept_lens) / len(accept_lens)
+            accept_len_var = sum((value - mean_accept_len) ** 2 for value in accept_lens) / len(accept_lens)
+        else:
+            accept_len_var = 0.0
+        self._speco_last_request_accept_len_records = records
+        self._speco_last_request_accept_len_var = accept_len_var
+        return records, accept_len_var
+
+    def _speco_flush_request_accept_len_payloads(self) -> None:
+        payloads = self._speco_pending_request_accept_len_payloads
+        if not payloads:
+            return
+        self._speco_pending_request_accept_len_payloads = []
+        path = os.getenv(
+            _SPECO_REQUEST_ACCEPT_LEN_HIST_LOG_PATH_ENV,
+            "/tmp/speco_vllm_request_accept_len_hist.jsonl",
+        )
+        _speco_append_jsonl_batch(path, payloads)
+        if _speco_diag_enabled(_SPECO_REQUEST_ACCEPT_LEN_HIST_PRINT_ENV, "0"):
+            for payload in payloads:
+                print(
+                    "[speco request accept len hist] %s"
+                    % json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
+                    flush=True,
+                )
+        if self._speco_should_log_request_accept_len_variance():
+            for payload in payloads:
+                print(
+                    "[speco request accept len] step=%s requests=%s request_accept_len_var=%.3f source=%s"
+                    % (
+                        payload["step"],
+                        payload["count"],
+                        payload["summary"]["var"],
+                        payload["source"],
+                    ),
+                    flush=True,
+                )
+
     def _speco_build_oldlogprob_collect_plan(self, batch: DataProto) -> dict[str, Any] | None:
         if not self._speco_oldlogprob_collection_enabled():
             return None
@@ -950,7 +1309,8 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
 
         batch_tensors = batch.batch
         required_keys = ("prompts", "responses", "attention_mask")
-        if any(key not in batch_tensors for key in required_keys):
+        missing_keys = [key for key in required_keys if key not in batch_tensors]
+        if missing_keys:
             return None
         prompts = batch_tensors["prompts"]
         responses = batch_tensors["responses"]
@@ -986,8 +1346,24 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
 
         prompt_lens: list[int] = []
         response_lens: list[int] = []
+        request_accept_lens = self._speco_request_accept_lengths(batch, batch_size)
+        require_request_ids = any(value is not None for value in request_accept_lens)
+        request_ids = self._speco_request_ids(batch, batch_size, require=require_request_ids)
+        request_completion_indices = self._speco_request_completion_indices(batch, batch_size)
+        request_elapsed_secs = self._speco_request_elapsed_secs(batch, batch_size)
+        all_request_accept_len_candidates = [
+            {
+                "batch_idx": batch_idx,
+                "request_id": request_ids[batch_idx],
+                "mean_accept_len": request_accept_lens[batch_idx],
+                "completion_index": request_completion_indices[batch_idx],
+                "elapsed_sec": request_elapsed_secs[batch_idx],
+            }
+            for batch_idx in range(batch_size)
+        ]
         candidate_count = 0
         selected_count = 0
+        candidates: list[dict[str, Any]] = []
         for batch_idx in range(batch_size):
             prompt_len = int(attention_mask[batch_idx, :prompt_width].detach().sum().item())
             if response_mask is not None:
@@ -1002,17 +1378,46 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             sample_key = f"{step_key}:{batch_idx}:{prompt_len}:{response_len}"
             if sample_rate < 1.0 and self._speco_hash_fraction(sample_key) >= sample_rate:
                 continue
-            owner = selected_count % owner_count
+            candidates.append(
+                {
+                    "batch_idx": batch_idx,
+                    "prompt_len": prompt_len,
+                    "response_len": response_len,
+                    "sample_key": sample_key,
+                    "request_id": request_ids[batch_idx],
+                    "mean_accept_len": request_accept_lens[batch_idx],
+                    "completion_index": request_completion_indices[batch_idx],
+                    "elapsed_sec": request_elapsed_secs[batch_idx],
+                    "hash": self._speco_hash_fraction(f"{step_key}:{request_ids[batch_idx]}:{batch_idx}:hard"),
+                }
+            )
+
+        scored_candidates = [candidate for candidate in candidates if candidate["mean_accept_len"] is not None]
+
+        is_hard = torch.zeros(batch_size, dtype=torch.bool)
+        hard_score = torch.zeros(batch_size, dtype=torch.float32)
+        mean_accept_len_tensor = torch.full((batch_size,), float("nan"), dtype=torch.float32)
+        for index, mean_accept_len in enumerate(request_accept_lens):
+            if mean_accept_len is not None:
+                mean_accept_len_tensor[index] = float(mean_accept_len)
+                hard_score[index] = float(-mean_accept_len)
+
+        def owner_has_capacity(owner: int) -> bool:
             if owner_counts[owner] >= max_per_owner:
-                continue
-            if max_tokens_per_owner is not None and owner_token_counts[owner] + hidden_rows > max_tokens_per_owner:
-                continue
-            max_start_offset = max(response_len - hidden_rows, 0)
+                return False
+            return max_tokens_per_owner is None or owner_token_counts[owner] + hidden_rows <= max_tokens_per_owner
+
+        def add_candidate(candidate: dict[str, Any], owner: int) -> bool:
+            nonlocal selected_count
+            if not owner_has_capacity(owner):
+                return False
+            batch_idx = int(candidate["batch_idx"])
+            max_start_offset = max(int(candidate["response_len"]) - hidden_rows, 0)
             if window_mode == "random":
-                random_offset = self._speco_hash_int(f"{sample_key}:window", max_start_offset)
+                random_offset = self._speco_hash_int(f"{candidate['sample_key']}:window", max_start_offset)
             else:
                 random_offset = 0
-            start = max(prompt_len - 1, 0) + random_offset
+            start = max(int(candidate["prompt_len"]) - 1, 0) + random_offset
             positions = torch.arange(start, start + hidden_rows, dtype=torch.long)
             collect_mask[batch_idx] = True
             hidden_positions[batch_idx, :] = positions
@@ -1021,6 +1426,82 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             owner_counts[owner] += 1
             owner_token_counts[owner] += hidden_rows
             selected_count += 1
+            return True
+
+        def add_round_robin(items: list[dict[str, Any]], *, start_owner: int = 0) -> int:
+            added = 0
+            next_owner = start_owner
+            for candidate in items:
+                if bool(collect_mask[int(candidate["batch_idx"])].item()):
+                    continue
+                for offset in range(owner_count):
+                    owner = (next_owner + offset) % owner_count
+                    if add_candidate(candidate, owner):
+                        added += 1
+                        next_owner = (owner + 1) % owner_count
+                        break
+            return added
+
+        hard_sample_ratio = max(float(training_cfg.get("dspark_hard_sample_ratio", 0.0) or 0.0), 0.0)
+        hard_candidate_ratio = max(float(training_cfg.get("dspark_hard_candidate_ratio", 0.0) or 0.0), 0.0)
+        hard_enabled = hard_sample_ratio > 0.0 and hard_candidate_ratio > 0.0
+        if not hard_enabled:
+            add_round_robin(candidates)
+        else:
+            if len(scored_candidates) < len(candidates):
+                logger.warning(
+                    "[speco hard] step=%s missing request-level accept stats for %s/%s candidates; "
+                    "unscored candidates are used as normal samples",
+                    self.global_steps,
+                    len(candidates) - len(scored_candidates),
+                    len(candidates),
+                )
+            capacity_per_owner = max_per_owner
+            if max_tokens_per_owner is not None:
+                capacity_per_owner = min(capacity_per_owner, max_tokens_per_owner // hidden_rows)
+            total_capacity = min(len(candidates), max(capacity_per_owner, 0) * owner_count)
+            batch_hard_count = round(int(training_cfg.get("batch_size_per_gpu", 4) or 4) * hard_sample_ratio)
+            batch_size_per_gpu = int(training_cfg.get("batch_size_per_gpu", 4) or 4)
+            minimum_hard_for_owners = owner_count * max(0, min(batch_size_per_gpu, batch_hard_count))
+            base_hard_pool_size = int(math.ceil(len(scored_candidates) * hard_candidate_ratio))
+            hard_pool_size = min(
+                len(scored_candidates),
+                max(base_hard_pool_size, minimum_hard_for_owners),
+            )
+            hard_pool = sorted(
+                scored_candidates,
+                key=lambda candidate: (float(candidate["mean_accept_len"]), float(candidate["hash"])),
+            )[:hard_pool_size]
+            target_hard = min(
+                total_capacity,
+                hard_pool_size,
+                max(round(total_capacity * hard_candidate_ratio), minimum_hard_for_owners),
+            )
+            selected_hard = hard_pool[:target_hard]
+            for candidate in selected_hard:
+                is_hard[int(candidate["batch_idx"])] = True
+            hard_added = add_round_robin(selected_hard)
+            if hard_added < target_hard:
+                logger.warning(
+                    "[speco hard] step=%s hard_collected=%s/%s; normal samples will fill remaining capacity",
+                    self.global_steps,
+                    hard_added,
+                    target_hard,
+                )
+            selected_hard_ids = {int(candidate["batch_idx"]) for candidate in selected_hard}
+            normal_candidates = [
+                candidate
+                for candidate in candidates
+                if int(candidate["batch_idx"]) not in selected_hard_ids
+            ]
+            normal_candidates.sort(key=lambda candidate: self._speco_hash_fraction(f"{candidate['sample_key']}:normal"))
+            add_round_robin(normal_candidates, start_owner=hard_added % owner_count)
+
+        self._speco_log_request_accept_lens(
+            candidates=all_request_accept_len_candidates,
+            is_hard=is_hard,
+            collect_mask=collect_mask,
+        )
 
         self._speco_last_raw_drafter_samples = candidate_count
         self._speco_last_oldlogprob_candidate_samples = candidate_count
@@ -1040,6 +1521,12 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             "candidate_count": candidate_count,
             "owner_token_counts": owner_token_counts,
             "window_mode": window_mode,
+            "request_ids": request_ids,
+            "request_mean_accept_len": mean_accept_len_tensor,
+            "request_is_hard": is_hard,
+            "request_hard_score": hard_score,
+            "request_completion_indices": request_completion_indices,
+            "request_elapsed_secs": request_elapsed_secs,
         }
 
     @staticmethod
@@ -1125,6 +1612,12 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         owner_rank = collect_plan["owner_rank"]
         prompt_lens = collect_plan["prompt_lens"]
         response_lens = collect_plan["response_lens"]
+        request_mean_accept_len = collect_plan.get("request_mean_accept_len")
+        request_is_hard = collect_plan.get("request_is_hard")
+        request_hard_score = collect_plan.get("request_hard_score")
+        request_completion_indices = collect_plan.get("request_completion_indices")
+        request_elapsed_secs = collect_plan.get("request_elapsed_secs")
+        request_ids = collect_plan.get("request_ids")
         buckets = [[] for _ in range(int(collect_plan["owner_count"]))]
         collected_rows = 0
         payload_bytes = 0
@@ -1219,6 +1712,24 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
                 "global_step": self.global_steps,
                 "replica_rank": owner,
             }
+            if isinstance(request_ids, (list, tuple)) and batch_idx < len(request_ids):
+                sample[_SPECO_VLLM_REQUEST_ID_KEY] = str(request_ids[batch_idx])
+            if torch.is_tensor(request_mean_accept_len) and batch_idx < int(request_mean_accept_len.numel()):
+                mean_accept_len = float(request_mean_accept_len[batch_idx].item())
+                if math.isfinite(mean_accept_len):
+                    sample[_SPECO_VLLM_REQUEST_MEAN_ACCEPT_LEN_KEY] = mean_accept_len
+            if torch.is_tensor(request_is_hard) and batch_idx < int(request_is_hard.numel()):
+                sample[_SPECO_VLLM_REQUEST_IS_HARD_KEY] = bool(request_is_hard[batch_idx].item())
+            if torch.is_tensor(request_hard_score) and batch_idx < int(request_hard_score.numel()):
+                sample[_SPECO_VLLM_REQUEST_HARD_SCORE_KEY] = float(request_hard_score[batch_idx].item())
+            if isinstance(request_completion_indices, (list, tuple)) and batch_idx < len(request_completion_indices):
+                completion_index = request_completion_indices[batch_idx]
+                if completion_index is not None:
+                    sample[_SPECO_VLLM_REQUEST_COMPLETION_INDEX_KEY] = int(completion_index)
+            if isinstance(request_elapsed_secs, (list, tuple)) and batch_idx < len(request_elapsed_secs):
+                elapsed_sec = request_elapsed_secs[batch_idx]
+                if elapsed_sec is not None:
+                    sample[_SPECO_VLLM_REQUEST_ELAPSED_SEC_KEY] = float(elapsed_sec)
             if ref_chunks:
                 sample["hidden_states_ref_chunks"] = ref_chunks
             elif hidden_ref is None:
@@ -1767,6 +2278,7 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             is_validation_generation = _speco_is_validation_generation(args, kwargs, gen_batch_output)
             if not is_validation_generation:
                 self._speco_store_rollout_metrics(gen_batch_output)
+                self._speco_log_request_accept_len_variance_from_batch(gen_batch_output, source="rollout")
                 collected = self._speco_collect_generation_samples(gen_batch_output)
                 if collected:
                     meta_info = getattr(gen_batch_output, "meta_info", None)
@@ -1929,6 +2441,7 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
                 0.0,
                 metrics["timing_s/drafter"] - known_drafter_timing,
             )
+            self._speco_flush_request_accept_len_payloads()
             return self._speco_update_output_metrics(actor_output, metrics)
 
         def update_weights_with_speco(manager_self, *args, **kwargs):

--- a/verl_speco/workers/speco_worker.py
+++ b/verl_speco/workers/speco_worker.py
@@ -568,6 +568,12 @@ class SpecoWorker(Worker):
             "hidden_last_hidden_select",
             "target_logprobs_position_start",
             "target_logprobs_position_end",
+            "_verl_request_mean_accept_len",
+            "_speco_vllm_request_id",
+            "_verl_is_hard",
+            "_verl_hard_score",
+            "_speco_vllm_request_completion_index",
+            "_speco_vllm_request_elapsed_sec",
         ):
             if key in batch:
                 metadata[key] = batch[key]
@@ -691,6 +697,12 @@ class SpecoWorker(Worker):
                 "hidden_last_hidden_filter",
                 "hidden_last_hidden_select",
                 "hidden_states_layout",
+                "_verl_request_mean_accept_len",
+                "_speco_vllm_request_id",
+                "_verl_is_hard",
+                "_verl_hard_score",
+                "_speco_vllm_request_completion_index",
+                "_speco_vllm_request_elapsed_sec",
                 "target_logprobs_position_start",
                 "target_logprobs_position_end",
                 "global_step",


### PR DESCRIPTION
## What changed

This PR adds request-aware hard sample collection for DSpark drafter training.

- Collects vLLM request-level speculative decoding acceptance stats, including request id, mean accept length, completion order, and elapsed time.
- Uses request mean accept length to select hard samples during old-logprob hidden-state collection.
- Preserves request metadata through rollout sample construction, worker collection, feature-store metadata, and drafter training batches.
- Keeps normal sample filling separate from explicitly labeled hard samples, so hard-sample quota does not get inflated by the random fill path.
- Adds request accept-length variance and histogram diagnostics, configurable through `request_accept_len_variance_interval_steps` and related environment variables.
- Updates the DSpark vLLM NPU example to enable hard sample collection and request accept-length logging.
- Adds integration tests for vLLM request-stat transport, hard sample selection, request metadata propagation, and sampler behavior.

## YAML config changes

Added/updated the following drafter training config values in `verl_speco/config/speco_base.yaml`:

```yaml
actor_rollout_ref:
  rollout:
    drafter:
      training:
        request_accept_len_variance_interval_steps: 1
        dspark_hard_candidate_ratio: 0.4
        dspark_hard_sample_ratio: 0.1