### PR TITLE
fix(sglang): request hidden states for every trainable drafter algorithm

### DIFF
--- a/tests/integration/test_sglang_adapter_contract.py
+++ b/tests/integration/test_sglang_adapter_contract.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import os
 import sys
 from types import SimpleNamespace
 
@@ -183,3 +184,113 @@ def test_eagle3_last_hidden_collection_does_not_request_raw_topk_without_logits(
     assert DFLASH_RETURN_AUX_HIDDEN_PARAM not in custom_params
     assert DRAFTER_RAW_TOP_LOGPROBS_PARAM not in custom_params
     assert sampling_params["custom_params"] == custom_params
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "expected_param", "other_param"),
+    [
+        ("EAGLE1", DRAFTER_RETURN_LAST_HIDDEN_PARAM, DFLASH_RETURN_AUX_HIDDEN_PARAM),
+        ("EAGLE2", DRAFTER_RETURN_LAST_HIDDEN_PARAM, DFLASH_RETURN_AUX_HIDDEN_PARAM),
+        ("EAGLE3", DRAFTER_RETURN_LAST_HIDDEN_PARAM, DFLASH_RETURN_AUX_HIDDEN_PARAM),
+        ("PEAGLE", DRAFTER_RETURN_LAST_HIDDEN_PARAM, DFLASH_RETURN_AUX_HIDDEN_PARAM),
+        ("DFLASH", DFLASH_RETURN_AUX_HIDDEN_PARAM, DRAFTER_RETURN_LAST_HIDDEN_PARAM),
+        ("DSPARK", DFLASH_RETURN_AUX_HIDDEN_PARAM, DRAFTER_RETURN_LAST_HIDDEN_PARAM),
+        ("DOMINO", DFLASH_RETURN_AUX_HIDDEN_PARAM, DRAFTER_RETURN_LAST_HIDDEN_PARAM),
+    ],
+)
+def test_every_trainable_drafter_requests_its_hidden_state_layout(
+    algorithm, expected_param, other_param
+) -> None:
+    """Every algorithm speco_worker can train must get its hidden states.
+
+    EAGLE-1/2 and P-EAGLE hard-raise in compute_loss without last_hidden_states,
+    and Domino consumes the same aux context layers as DFlash, so none of them
+    can be left out of the request gate.
+    """
+    server = _SpecoSGLangHttpServerMixin()
+    server.replica_rank = 0
+    server._drafter_collection_step = None
+    server._drafter_collection_samples = 0
+    server._drafter_collection_tokens = 0
+    server._speco_drafter_config = {
+        "enable": True,
+        "enable_drafter_training": True,
+        "speculative_algorithm": algorithm,
+        "training": {
+            "collect_hidden_states_from_sgl": True,
+            "collect_interval_steps": 5,
+            "use_logits": False,
+            "hidden_state_window_mode": "front",
+        },
+    }
+
+    sampling_params: dict = {}
+    should_collect, _, custom_params = server._speco_request_hidden_state_params(
+        sampling_params,
+        prompt_len=8,
+        request_id=f"req-{algorithm.lower()}",
+        collection_global_steps=5,
+        max_new_tokens=16,
+    )
+
+    assert should_collect is True
+    assert custom_params[expected_param] is True
+    assert other_param not in custom_params
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "expected"),
+    [
+        ("EAGLE1", "1"),
+        ("EAGLE2", "1"),
+        ("EAGLE3", "1"),
+        ("PEAGLE", "1"),
+        ("DFLASH", "0"),
+        ("DSPARK", "0"),
+        ("DOMINO", "0"),
+    ],
+)
+def test_last_hidden_env_follows_the_shared_layout_resolver(
+    monkeypatch, algorithm, expected
+) -> None:
+    from verl_speco.integration.sglang_runtime import _set_sglang_patch_envs
+
+    monkeypatch.delenv("VERL_SGLANG_DRAFTER_RETURN_LAST_HIDDEN", raising=False)
+    _set_sglang_patch_envs(
+        {
+            "enable": True,
+            "enable_drafter_training": True,
+            "speculative_algorithm": algorithm,
+            "training": {
+                "collect_hidden_states_from_sgl": True,
+                "use_logits": False,
+            },
+        }
+    )
+
+    assert os.environ["VERL_SGLANG_DRAFTER_RETURN_LAST_HIDDEN"] == expected
+
+
+def test_hidden_state_gates_stay_off_without_drafter_collection() -> None:
+    from verl_speco.integration.sglang_runtime import (
+        _drafter_uses_dflash_aux_hidden,
+        _drafter_uses_eagle_last_hidden,
+    )
+
+    for drafter_cfg in (
+        {"enable": False, "speculative_algorithm": "EAGLE3", "training": {}},
+        {
+            "enable": True,
+            "enable_drafter_training": False,
+            "speculative_algorithm": "DFLASH",
+            "training": {"collect_hidden_states_from_sgl": True},
+        },
+        {
+            "enable": True,
+            "enable_drafter_training": True,
+            "speculative_algorithm": "EAGLE3",
+            "training": {"collect_hidden_states_from_sgl": True, "use_logits": True},
+        },
+    ):
+        assert _drafter_uses_eagle_last_hidden(drafter_cfg) is False
+        assert _drafter_uses_dflash_aux_hidden(drafter_cfg) is False

--- a/verl_speco/integration/sglang_runtime.py
+++ b/verl_speco/integration/sglang_runtime.py
@@ -42,6 +42,9 @@ from verl_speco.integration.sglang_adapter import (
     sglang_needs_qwen3_rope_compat_patch,
     speco_step_matches_interval,
 )
+from verl_speco.integration.oldlogprob_layer_ids import (
+    resolve_drafter_hidden_states_layout,
+)
 
 try:
     import torch as _torch
@@ -158,28 +161,34 @@ def clear_sglang_runtime_config() -> None:
     os.environ.pop(SPECO_SGLANG_DRAFTER_CONFIG_ENV, None)
 
 
-def _drafter_uses_eagle_last_hidden(drafter_cfg: dict[str, Any]) -> bool:
-    algorithm = str(drafter_cfg.get("speculative_algorithm", "") or "").upper()
+def _drafter_collects_hidden_from_sgl(drafter_cfg: dict[str, Any]) -> bool:
+    """Whether drafter training reads hidden states off the SGLang rollout."""
     training_cfg = drafter_cfg.get("training") or {}
     return bool(
-        algorithm == "EAGLE3"
-        and drafter_cfg.get("enable")
+        drafter_cfg.get("enable")
         and drafter_cfg.get("enable_drafter_training")
         and training_cfg.get("collect_hidden_states_from_sgl")
         and not training_cfg.get("use_logits")
     )
+
+
+def _drafter_hidden_states_layout(drafter_cfg: dict[str, Any]) -> str:
+    return resolve_drafter_hidden_states_layout(
+        drafter_cfg.get("speculative_algorithm"),
+        drafter_cfg.get("training") or {},
+    )
+
+
+def _drafter_uses_eagle_last_hidden(drafter_cfg: dict[str, Any]) -> bool:
+    return _drafter_collects_hidden_from_sgl(
+        drafter_cfg
+    ) and _drafter_hidden_states_layout(drafter_cfg).startswith("eagle3_")
 
 
 def _drafter_uses_dflash_aux_hidden(drafter_cfg: dict[str, Any]) -> bool:
-    algorithm = str(drafter_cfg.get("speculative_algorithm", "") or "").upper()
-    training_cfg = drafter_cfg.get("training") or {}
-    return bool(
-        algorithm in {"DFLASH", "DSPARK"}
-        and drafter_cfg.get("enable")
-        and drafter_cfg.get("enable_drafter_training")
-        and training_cfg.get("collect_hidden_states_from_sgl")
-        and not training_cfg.get("use_logits")
-    )
+    return _drafter_collects_hidden_from_sgl(
+        drafter_cfg
+    ) and _drafter_hidden_states_layout(drafter_cfg).startswith("dflash_")
 
 
 def _positive_int_or_none(value: Any) -> Optional[int]:


### PR DESCRIPTION
## Problem

The SGLang request gate carries its own copy of the algorithm-to-hidden-state-layout mapping:

```python
def _drafter_uses_eagle_last_hidden(drafter_cfg):
    algorithm = str(drafter_cfg.get("speculative_algorithm", "") or "").upper()
    return bool(algorithm == "EAGLE3" and ...)

def _drafter_uses_dflash_aux_hidden(drafter_cfg):
    algorithm = str(drafter_cfg.get("speculative_algorithm", "") or "").upper()
    return bool(algorithm in {"DFLASH", "DSPARK"} and ...)
```

Both sets have drifted from what `speco_worker` can actually build a training backend for:

- **EAGLE-1 / EAGLE-2 / P-EAGLE** all need `last_hidden_states`. `Eagle1TrainerBackend.compute_loss` and `PEagleTrainerBackend.compute_loss` both raise `ValueError("... requires last_hidden_states")` without it, and both `build_model` implementations reject `use_logits=True`, so there is no fallback.
- **Domino** consumes the same aux context layers as DFlash. `DominoTrainerBackend` subclasses `DFlashTrainerBackend` and its `compute_loss` splits `batch["hidden_states"]` into `num_context_layers`.

None of the four appear in either set. On an SGLang rollout with `collect_hidden_states_from_sgl`, they request nothing at all and drafter training is starved.

EAGLE-1/2 are especially easy to miss here: `Eagle1TrainerBackend.model_type` deliberately reports `"eagle3"` so it can reuse the EAGLE-3 data plumbing, but this gate reads the raw config string, so the masquerade never reaches it.

## Fix

`oldlogprob_layer_ids.resolve_drafter_hidden_states_layout` is already the shared answer to this exact question. `speco_worker` and `speco_ray_trainer` both use it, its docstring spells out the split ("DFlash-family drafters (DFlash, DSpark, Domino) consume the raw aux context layers, while EAGLE-family drafters also need the final hidden state"), and `DFLASH_FAMILY_ALGORITHMS` already lists `DOMINO`.

Route the SGLang gate through it instead of keeping a second copy that can drift again. The two predicates keep their names and their mutual exclusivity, and the shared collection preconditions move into one helper.

`oldlogprob_layer_ids` imports nothing from `verl_speco`, so there is no import cycle.

## Validation

Ran a before/after repro on both `main` and this branch. For every algorithm `speco_worker` accepts, it asks what layout the trainer needs (via the shared resolver) and what the SGLang gate actually requests.

<details>
<summary>Before/after repro output</summary>

```
=================== before: main (333b754) ===================
algorithm  trainer needs          sglang requests        verdict
----------------------------------------------------------------
EAGLE1     eagle3_aux_plus_last   NOTHING                MISMATCH
EAGLE2     eagle3_aux_plus_last   NOTHING                MISMATCH
EAGLE3     eagle3_aux_plus_last   last_hidden            ok
PEAGLE     eagle3_aux_plus_last   NOTHING                MISMATCH
DFLASH     dflash_aux             dflash_aux_hidden      ok
DSPARK     dflash_aux_plus_last   dflash_aux_hidden      ok
DOMINO     dflash_aux             NOTHING                MISMATCH

[verdict]
          algorithms with no hidden states: EAGLE1, EAGLE2, PEAGLE, DOMINO
          RESULT: drafter training is starved on SGLang (bug present)

=================== after: this branch ===================
algorithm  trainer needs          sglang requests        verdict
----------------------------------------------------------------
EAGLE1     eagle3_aux_plus_last   last_hidden            ok
EAGLE2     eagle3_aux_plus_last   last_hidden            ok
EAGLE3     eagle3_aux_plus_last   last_hidden            ok
PEAGLE     eagle3_aux_plus_last   last_hidden            ok
DFLASH     dflash_aux             dflash_aux_hidden      ok
DSPARK     dflash_aux_plus_last   dflash_aux_hidden      ok
DOMINO     dflash_aux             dflash_aux_hidden      ok

[verdict]
          every algorithm requests the layout its trainer needs
          RESULT: gate matches the shared resolver (fixed)
```

</details>

## Tests

Three new tests in `tests/integration/test_sglang_adapter_contract.py`:

- `test_every_trainable_drafter_requests_its_hidden_state_layout` walks all seven algorithms through the real request path and pins which custom param each one gets.
- `test_last_hidden_env_follows_the_shared_layout_resolver` covers `VERL_SGLANG_DRAFTER_RETURN_LAST_HIDDEN` for the same seven.
- `test_hidden_state_gates_stay_off_without_drafter_collection` pins the preconditions that must keep both gates off (`enable=False`, `enable_drafter_training=False`, `use_logits=True`).

Full CPU suite (`tests/integration tests/compat tests/config tests/examples`) run on both sides:

<details>
<summary>Test suite before/after</summary>

```
### BASELINE (origin/main, 333b754) ###
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DSPARK-veomni-npu-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DFLASH-veomni-npu-veomni_lm_head_sparse]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE3-veomni-cuda-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE1-fsdp-npu-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DOMINO-fsdp2-cuda-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_transfer_waits_after_actor_update
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_async_publish_sets_pending_ref_and_waits_before_next_publish
FAILED tests/integration/test_dspark_trainer_backend.py::test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names
FAILED tests/integration/test_verl_npu_vllm_compat.py::test_factory_fused_moe_survives_verl_npu_patch_import
9 failed, 245 passed, 2 warnings in 33.60s

### THIS BRANCH ###
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DSPARK-veomni-npu-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DFLASH-veomni-npu-veomni_lm_head_sparse]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE3-veomni-cuda-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE1-fsdp-npu-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DOMINO-fsdp2-cuda-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_transfer_waits_after_actor_update
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_async_publish_sets_pending_ref_and_waits_before_next_publish
FAILED tests/integration/test_dspark_trainer_backend.py::test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names
FAILED tests/integration/test_verl_npu_vllm_compat.py::test_factory_fused_moe_survives_verl_npu_patch_import
9 failed, 260 passed, 2 warnings in 22.04s
```

The same 9 tests fail on `main` and on this branch. They need optional dependencies (VeOmni, the NPU vLLM stack) that are absent in this environment, so they are pre-existing and unrelated. The `+15` on this branch are the new parametrized tests above.

</details>
