### PR TITLE
fix(peagle): refuse a reduced draft vocabulary without a t2d/d2t mapping

### DIFF
--- a/tests/integration/test_peagle_backend_contract.py
+++ b/tests/integration/test_peagle_backend_contract.py
@@ -170,6 +170,101 @@ def test_peagle_vllm_guardrail() -> None:
         _speculative_method_from_drafter({"speculative_algorithm": "PEAGLE"})
 
 
+def _peagle_backend_and_target(draft_vocab_size=None):
+    from omegaconf import OmegaConf
+    from transformers import LlamaConfig
+
+    from verl_speco.backends.peagle_trainer_backend import PEagleTrainerBackend
+
+    training: dict = {
+        "peagle_num_draft_layers": 1,
+        "peagle_num_aux_hidden_states": 3,
+        "peagle_num_depths": 2,
+    }
+    if draft_vocab_size is not None:
+        training["peagle_draft_vocab_size"] = draft_vocab_size
+
+    target_hf_config = LlamaConfig(
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_hidden_layers=2,
+        vocab_size=32,
+        max_position_embeddings=64,
+    )
+    backend = PEagleTrainerBackend(
+        OmegaConf.create(
+            {
+                "rollout": {"drafter": {"model_path": None, "training": training}},
+                "model": {"path": "/tmp/none"},
+            }
+        ),
+        target_hf_config,
+    )
+    return backend, target_hf_config
+
+
+def test_peagle_rejects_reduced_draft_vocab_without_mapping() -> None:
+    """A reduced draft vocabulary needs a real frequency-derived t2d/d2t pair.
+
+    Without one the model constructor falls back to "the first draft_vocab_size
+    target ids", which is an arbitrary slice of any real tokenizer and leaves the
+    draft unable to ever emit the rest. EAGLE-3 already refuses this
+    configuration; P-EAGLE used to accept it silently.
+    """
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    backend, _ = _peagle_backend_and_target(draft_vocab_size=16)
+
+    with pytest.raises(ValueError) as excinfo:
+        backend.build_model()
+
+    message = str(excinfo.value)
+    assert "draft_vocab_size differs from target vocab_size" in message
+    # Name the algorithm the user configured, not the EAGLE-3 backend it reuses.
+    assert message.startswith("PEAGLE")
+
+
+def test_peagle_identity_vocab_mapping_passes_validation() -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    from verl_speco.models.peagle import LlamaForCausalLMPeagle
+
+    backend, target_hf_config = _peagle_backend_and_target()
+    draft_config = backend._build_draft_config(None, target_hf_config)
+    assert draft_config.draft_vocab_size == draft_config.vocab_size
+
+    # Must not raise: the full-vocabulary default needs no frequency mapping.
+    backend._validate_vocab_mapping(LlamaForCausalLMPeagle(draft_config))
+
+
+def test_vocab_mapping_validation_names_the_failing_algorithm() -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    from types import SimpleNamespace
+
+    from omegaconf import OmegaConf
+
+    from verl_speco.backends.eagle3_trainer_backend import Eagle3TrainerBackend
+    from verl_speco.backends.peagle_trainer_backend import PEagleTrainerBackend
+
+    empty_config = OmegaConf.create(
+        {"rollout": {"drafter": {"training": {}}}, "model": {"path": "/tmp/none"}}
+    )
+    drafter_without_mapping = SimpleNamespace(vocab_size=32, draft_vocab_size=32)
+
+    for backend_cls, expected_label in (
+        (Eagle3TrainerBackend, "EAGLE3"),
+        (PEagleTrainerBackend, "PEAGLE"),
+    ):
+        backend = backend_cls(empty_config, OmegaConf.create({}))
+        with pytest.raises(AttributeError) as excinfo:
+            backend._validate_vocab_mapping(drafter_without_mapping)
+        assert str(excinfo.value).startswith(expected_label)
+
+
 def test_peagle_batch_assembly_matches_reference_shift() -> None:
     """base_trainer must apply the reference target-wrapper shift for P-EAGLE:
     row p pairs unshifted aux[p] with token x[p+1], supervised by the

--- a/verl_speco/backends/eagle3_trainer_backend.py
+++ b/verl_speco/backends/eagle3_trainer_backend.py
@@ -786,26 +786,29 @@ class Eagle3TrainerBackend:
             return False
 
     def _validate_vocab_mapping(self, drafter_module) -> None:
+        # Subclasses share this validator, so name the algorithm that actually
+        # failed instead of always blaming EAGLE3.
+        label = str(self.model_type).upper()
         if not hasattr(drafter_module, "t2d") or not hasattr(drafter_module, "d2t"):
             raise AttributeError(
-                "EAGLE3 draft model does not have t2d/d2t vocab mapping buffers"
+                f"{label} draft model does not have t2d/d2t vocab mapping buffers"
             )
 
         if drafter_module.t2d.numel() != drafter_module.vocab_size:
             raise ValueError(
-                f"EAGLE3 t2d shape mismatch: expected {drafter_module.vocab_size}, "
+                f"{label} t2d shape mismatch: expected {drafter_module.vocab_size}, "
                 f"got {drafter_module.t2d.numel()}"
             )
         if drafter_module.d2t.numel() != drafter_module.draft_vocab_size:
             raise ValueError(
-                f"EAGLE3 d2t shape mismatch: expected {drafter_module.draft_vocab_size}, "
+                f"{label} d2t shape mismatch: expected {drafter_module.draft_vocab_size}, "
                 f"got {drafter_module.d2t.numel()}"
             )
 
         selected_vocab_size = int(drafter_module.t2d.sum().item())
         if selected_vocab_size != drafter_module.draft_vocab_size:
             raise ValueError(
-                f"EAGLE3 vocab mapping selects {selected_vocab_size} tokens, "
+                f"{label} vocab mapping selects {selected_vocab_size} tokens, "
                 f"but draft_vocab_size is {drafter_module.draft_vocab_size}"
             )
 

--- a/verl_speco/backends/peagle_trainer_backend.py
+++ b/verl_speco/backends/peagle_trainer_backend.py
@@ -256,17 +256,48 @@ class PEagleTrainerBackend(Eagle3TrainerBackend):
         draft_config = self._build_draft_config(spec_model_path, target_hf_config)
         self.vocab_size = draft_config.vocab_size
 
+        checkpoint_has_vocab_mapping = False
         if spec_model_path and os.path.exists(
             os.path.join(spec_model_path, "config.json")
         ):
             log_drafter_checkpoint_step(
                 logger, spec_model_path, action="Loading P-EAGLE drafter weights"
             )
-            drafter_module = LlamaForCausalLMPeagle.from_pretrained(
-                spec_model_path, config=draft_config
+            loaded = LlamaForCausalLMPeagle.from_pretrained(
+                spec_model_path,
+                config=draft_config,
+                output_loading_info=True,
             )
+            if isinstance(loaded, tuple):
+                drafter_module, loading_info = loaded
+                missing_keys = set(loading_info.get("missing_keys", []))
+                checkpoint_has_vocab_mapping = not {"t2d", "d2t"}.intersection(
+                    missing_keys
+                )
+            else:
+                drafter_module = loaded
+                checkpoint_has_vocab_mapping = self._has_valid_vocab_mapping(
+                    drafter_module
+                )
         else:
             drafter_module = LlamaForCausalLMPeagle(draft_config)
+
+        # A reduced draft vocabulary is only meaningful with a real t2d/d2t pair
+        # derived from token frequency. The model's constructor falls back to
+        # "the first draft_vocab_size target ids", which is an arbitrary slice of
+        # any real tokenizer, so refuse it exactly like the EAGLE-3 backend does
+        # instead of silently training a draft that can never emit the rest.
+        if drafter_module.draft_vocab_size != drafter_module.vocab_size:
+            if checkpoint_has_vocab_mapping and self._has_valid_vocab_mapping(
+                drafter_module
+            ):
+                logger.debug("Using P-EAGLE vocab mapping loaded from draft checkpoint")
+            else:
+                raise ValueError(
+                    "PEAGLE draft_vocab_size differs from target vocab_size, but the draft "
+                    "checkpoint does not provide valid t2d/d2t vocab mapping buffers"
+                )
+        self._validate_vocab_mapping(drafter_module)
 
         # P-EAGLE trains the draft embeddings (speculators sets embed_requires_grad=True),
         # so seed them from the target but do NOT freeze.


### PR DESCRIPTION
## Problem

`Eagle3TrainerBackend.build_model` refuses a reduced draft vocabulary that has no real mapping behind it:

```python
if drafter_module.draft_vocab_size != drafter_module.vocab_size:
    if checkpoint_has_vocab_mapping and self._has_valid_vocab_mapping(drafter_module):
        logger.debug("Using EAGLE3 vocab mapping loaded from draft checkpoint")
    else:
        raise ValueError(
            "EAGLE3 draft_vocab_size differs from target vocab_size, but the draft checkpoint "
            "does not provide valid t2d/d2t vocab mapping buffers"
        )
self._validate_vocab_mapping(drafter_module)
```

`PEagleTrainerBackend` overrides `build_model` entirely and has neither the guard nor the validation call.

Setting `peagle_draft_vocab_size` below the target vocabulary therefore falls through to the model constructor's default:

```python
t2d = torch.zeros(self.vocab_size, dtype=torch.bool)
t2d[: self.draft_vocab_size] = True
```

That means "the draft vocabulary is target token ids `0..N-1`". On any real tokenizer that is an arbitrary slice with no relation to token frequency, and the draft can never emit anything outside it. Nothing in training complains, because `compute_loss` restricts the target logits to the very same slice via `selected_token_ids()`, so the loss and the accuracy metric both look healthy while the draft is structurally incapable of proposing most of the vocabulary.

## Fix

Give P-EAGLE the same guard, loading the checkpoint with `output_loading_info=True` so a supplied mapping is detected exactly the way EAGLE-3 detects it, and run `_validate_vocab_mapping` afterwards.

The full-vocabulary default (`draft_vocab_size == vocab_size`, which is what you get when `peagle_draft_vocab_size` is unset) is unaffected and still needs no mapping file.

`_validate_vocab_mapping` is inherited by every EAGLE-family backend, so its messages now name the algorithm that actually failed instead of always saying `EAGLE3`. The label comes from `model_type`, so it matches the `speculative_algorithm` value the user configured.

## Validation

Ran a before/after repro on both `main` and this branch. It configures a reduced draft vocabulary (16 of the target's 32 tokens) with no `t2d`/`d2t` supplied, prints the fallback mapping the model constructs, and reports whether the backend refuses the configuration.

<details>
<summary>Before/after repro output</summary>

```
=================== before: main (333b754) ===================
target vocab_size       = 32
peagle_draft_vocab_size = 16
t2d/d2t supplied        = no

[fallback mapping the model constructs]
          draft can emit target ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
          d2t buffer               : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
          this is the first N target ids, not a frequency-derived subset

[does the backend refuse it?]
          EAGLE-3 : yes
          P-EAGLE : accepted the vocab config, then failed later for an unrelated reason: HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/tmp/none'

[verdict]
          RESULT: P-EAGLE trains on an arbitrary vocab slice (bug present)

=================== after: this branch ===================
target vocab_size       = 32
peagle_draft_vocab_size = 16
t2d/d2t supplied        = no

[fallback mapping the model constructs]
          draft can emit target ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
          d2t buffer               : [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
          this is the first N target ids, not a frequency-derived subset

[does the backend refuse it?]
          EAGLE-3 : yes
          P-EAGLE : REFUSED: PEAGLE draft_vocab_size differs from target vocab_size, but the draft checkpoint does not provide valid t2d/d2t vocab mapping buffers

[verdict]
          RESULT: P-EAGLE refuses the unmapped reduced vocab (fixed)
```

On `main` the misconfiguration only surfaces as an unrelated failure much later (here, the placeholder target path used by the repro). With a real target path it does not surface at all.

</details>

## Tests

Three new tests in `tests/integration/test_peagle_backend_contract.py`:

- `test_peagle_rejects_reduced_draft_vocab_without_mapping` covers the guard and its message.
- `test_peagle_identity_vocab_mapping_passes_validation` pins that the full-vocabulary default still needs no mapping.
- `test_vocab_mapping_validation_names_the_failing_algorithm` covers the label on both EAGLE-3 and P-EAGLE.

Full CPU suite (`tests/integration tests/compat tests/config tests/examples`) run on both sides:

<details>
<summary>Test suite before/after</summary>

```
### BASELINE (origin/main, 333b754) ###
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DSPARK-veomni-npu-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DFLASH-veomni-npu-veomni_lm_head_sparse]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE3-veomni-cuda-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE1-fsdp-npu-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DOMINO-fsdp2-cuda-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_transfer_waits_after_actor_update
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_async_publish_sets_pending_ref_and_waits_before_next_publish
FAILED tests/integration/test_dspark_trainer_backend.py::test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names
FAILED tests/integration/test_verl_npu_vllm_compat.py::test_factory_fused_moe_survives_verl_npu_patch_import
9 failed, 245 passed, 2 warnings in 33.60s

### THIS BRANCH ###
(same 9 failures)
9 failed, 248 passed, 2 warnings in 21.41s
```

The same 9 tests fail on `main` and on this branch. They need optional dependencies (VeOmni, the NPU vLLM stack) that are absent in this environment, so they are pre-existing and unrelated. The `+3` on this branch are the new tests above.

</details>
