### PR TITLE
fix(eagle3,peagle): default d2t to the offset identity instead of arange

### DIFF
--- a/tests/integration/test_draft_vocab_mapping_contract.py
+++ b/tests/integration/test_draft_vocab_mapping_contract.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contract tests for the draft vocabulary mapping buffers.
+
+``d2t`` holds offsets, not absolute ids: the target id of draft id ``i`` is
+``i + d2t[i]``. That is what ``process_token_dict_to_mappings`` emits and what the
+serving engines apply, so every producer of a ``d2t`` buffer has to agree on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _tiny_eagle3_config(vocab_size: int, draft_vocab_size: int):
+    from transformers import LlamaConfig
+
+    return LlamaConfig(
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_hidden_layers=1,
+        vocab_size=vocab_size,
+        draft_vocab_size=draft_vocab_size,
+        target_hidden_size=8,
+        num_aux_hidden_states=3,
+        pad_token_id=0,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=64,
+    )
+
+
+def _tiny_peagle_config(vocab_size: int, draft_vocab_size: int):
+    from verl_speco.models.peagle import PeagleConfig
+
+    return PeagleConfig(
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_hidden_layers=1,
+        num_draft_layers=1,
+        target_hidden_size=8,
+        num_aux_hidden_states=3,
+        vocab_size=vocab_size,
+        draft_vocab_size=draft_vocab_size,
+        mask_token_id=vocab_size - 1,
+        pad_token_id=0,
+        rms_norm_eps=1e-6,
+        max_position_embeddings=64,
+    )
+
+
+def _draft_models(vocab_size: int, draft_vocab_size: int):
+    from verl_speco.models.eagle.llama_eagle import LlamaForCausalLMEagle3
+    from verl_speco.models.peagle import LlamaForCausalLMPeagle
+
+    return {
+        "eagle3": LlamaForCausalLMEagle3(
+            _tiny_eagle3_config(vocab_size, draft_vocab_size)
+        ),
+        "peagle": LlamaForCausalLMPeagle(
+            _tiny_peagle_config(vocab_size, draft_vocab_size)
+        ),
+    }
+
+
+@pytest.mark.parametrize("name", ["eagle3", "peagle"])
+def test_default_d2t_is_the_offset_identity(name) -> None:
+    """The default mapping must be the identity under the offset convention.
+
+    ``torch.arange`` looks like an identity only if ``d2t`` held absolute ids. It
+    does not, so an arange default resolves to ``target_id = 2 * draft_id``.
+    """
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    model = _draft_models(vocab_size=32, draft_vocab_size=32)[name]
+
+    assert torch.equal(model.d2t, torch.zeros(32, dtype=model.d2t.dtype))
+
+    # This is what the serving engine computes.
+    target_ids = torch.arange(model.draft_vocab_size) + model.d2t
+    assert torch.equal(target_ids, torch.arange(32))
+    assert int(target_ids.max()) < model.vocab_size
+
+
+@pytest.mark.parametrize("name", ["eagle3", "peagle"])
+def test_default_d2t_stays_inside_the_target_vocabulary(name) -> None:
+    """A reduced draft vocabulary must still resolve to in-range target ids."""
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    model = _draft_models(vocab_size=32, draft_vocab_size=8)[name]
+
+    target_ids = torch.arange(model.draft_vocab_size) + model.d2t
+    assert int(target_ids.max()) < model.vocab_size
+    # t2d marks the same tokens the offsets resolve to.
+    assert torch.equal(torch.nonzero(model.t2d, as_tuple=False).flatten(), target_ids)
+
+
+def test_generated_mapping_round_trips_through_the_offset_convention() -> None:
+    """The repo's own mapping generator emits offsets, so decoding must match."""
+    torch = pytest.importorskip("torch")
+    from collections import Counter
+
+    from verl_speco.data.preprocessing import process_token_dict_to_mappings
+
+    token_dict = Counter({3: 10, 9: 8, 17: 5, 21: 2})
+    d2t, t2d = process_token_dict_to_mappings(
+        token_dict, draft_vocab_size=4, target_vocab_size=32
+    )
+
+    target_ids = torch.arange(4) + d2t
+    assert target_ids.tolist() == [3, 9, 17, 21]
+    assert torch.nonzero(t2d, as_tuple=False).flatten().tolist() == [3, 9, 17, 21]

--- a/verl_speco/models/eagle/llama_eagle.py
+++ b/verl_speco/models/eagle/llama_eagle.py
@@ -1493,10 +1493,14 @@ class LlamaForCausalLMEagle3(Eagle3DraftModel):
 
         self.post_init()
 
-        # create vocab buffers
+        # Create vocab buffers. d2t holds OFFSETS, not absolute ids: the target id
+        # of draft id i is `i + d2t[i]`. That is what
+        # `preprocessing.process_token_dict_to_mappings` emits (`used_tokens[i] - i`)
+        # and what the serving engines apply, so the identity mapping used when no
+        # frequency mapping is supplied is all zeros.
         t2d = torch.zeros(self.vocab_size, dtype=torch.bool)
         t2d[: self.draft_vocab_size] = True
-        d2t = torch.arange(self.draft_vocab_size, dtype=torch.int64)
+        d2t = torch.zeros(self.draft_vocab_size, dtype=torch.int64)
         self.register_buffer("t2d", t2d)
         self.register_buffer("d2t", d2t)
 

--- a/verl_speco/models/peagle/modeling_peagle.py
+++ b/verl_speco/models/peagle/modeling_peagle.py
@@ -268,9 +268,12 @@ class LlamaForCausalLMPeagle(DraftModel):
 
         self.post_init()
 
+        # d2t holds OFFSETS, not absolute ids: the target id of draft id i is
+        # `i + d2t[i]`, so the identity mapping is all zeros. See the EAGLE-3
+        # draft for the full note.
         t2d = torch.zeros(self.vocab_size, dtype=torch.bool)
         t2d[: self.draft_vocab_size] = True
-        d2t = torch.arange(self.draft_vocab_size, dtype=torch.int64)
+        d2t = torch.zeros(self.draft_vocab_size, dtype=torch.int64)
         self.register_buffer("t2d", t2d)
         self.register_buffer("d2t", d2t)
         nn.init.normal_(self.mask_hidden, mean=0.0, std=1.0)


### PR DESCRIPTION
## Problem

`d2t` holds **offsets**, not absolute ids: the target id of draft id `i` is `i + d2t[i]`.

That is what this repo's own mapping generator emits:

```python
# verl_speco/data/preprocessing.py
d2t = [used_tokens[i] - i for i in range(len(used_tokens))]
```

and it is what the serving engine applies:

```python
# vLLM, model_executor/models/llama_eagle3.py
base = torch.arange(self.config.draft_vocab_size, device=logits.device)
targets = base + self.draft_id_to_target_id
logits_new[:, targets] = logits
```

vLLM even initializes its own copy of the buffer to `torch.zeros`, which is the identity under this convention.

Both draft models here default it to `torch.arange` instead:

```python
d2t = torch.arange(self.draft_vocab_size, dtype=torch.int64)   # llama_eagle.py, modeling_peagle.py
```

Under the offset convention that resolves draft id `i` to target id `2 * i`. For a full-vocabulary draft the top of the range lands outside the target vocabulary entirely, so the engine's `logits_new[:, targets] = logits` indexes out of bounds.

## Scope

Nothing inside this repo reads `d2t`; the backend only validates its shape, and the loss uses `t2d`. The exposure is entirely on the export path:

- Hot publish is unaffected. `_get_trainable_state_dict` drops non-floating tensors, so `d2t` never goes over the wire and the engine keeps its own zero-initialized copy.
- `_get_full_export_state_dict` deliberately keeps "persistent buffers such as vocab mappings", so every checkpoint written to disk carries the value.

Neither `load_vocab_mapping` nor `generate_vocab_mapping_file` has a caller in-tree, so a freshly trained drafter always exports the constructor default rather than a frequency-derived mapping.

## Fix

Default the buffer to `torch.zeros` in both draft models and state the convention in a comment next to it.

Checkpoints already exported with the `arange` buffer keep it on reload, since `from_pretrained` overwrites the default. They need their `d2t` rewritten (all zeros for a full-vocabulary draft).

## Validation

Ran a before/after repro on both `main` and this branch. It shows what the repo's own generator emits, then applies vLLM's exact formula to the default buffer of both drafts.

<details>
<summary>Before/after repro output</summary>

```
=================== before: main (333b754) ===================
[what the repo's own mapping generator emits]
          used_tokens          = [3, 9, 17, 21]
          generated d2t        = [3, 8, 15, 18]
          arange(4) + d2t      = [3, 9, 17, 21]
          so d2t holds OFFSETS, and the identity mapping is all zeros

[full-vocabulary draft, no mapping supplied]
          EAGLE-3
            d2t[:8]              = [0, 1, 2, 3, 4, 5, 6, 7]
            engine target ids[:8]= [0, 2, 4, 6, 8, 10, 12, 14]
            max target id        = 62 (vocab_size=32)
            identity mapping     = False
            all ids in range     = False
          P-EAGLE
            d2t[:8]              = [0, 1, 2, 3, 4, 5, 6, 7]
            engine target ids[:8]= [0, 2, 4, 6, 8, 10, 12, 14]
            max target id        = 62 (vocab_size=32)
            identity mapping     = False
            all ids in range     = False

[verdict]
          RESULT: the default d2t resolves to the wrong target ids (bug present)

=================== after: this branch ===================
[what the repo's own mapping generator emits]
          used_tokens          = [3, 9, 17, 21]
          generated d2t        = [3, 8, 15, 18]
          arange(4) + d2t      = [3, 9, 17, 21]
          so d2t holds OFFSETS, and the identity mapping is all zeros

[full-vocabulary draft, no mapping supplied]
          EAGLE-3
            d2t[:8]              = [0, 0, 0, 0, 0, 0, 0, 0]
            engine target ids[:8]= [0, 1, 2, 3, 4, 5, 6, 7]
            max target id        = 31 (vocab_size=32)
            identity mapping     = True
            all ids in range     = True
          P-EAGLE
            d2t[:8]              = [0, 0, 0, 0, 0, 0, 0, 0]
            engine target ids[:8]= [0, 1, 2, 3, 4, 5, 6, 7]
            max target id        = 31 (vocab_size=32)
            identity mapping     = True
            all ids in range     = True

[verdict]
          RESULT: the default d2t is the offset identity (fixed)
```

`max target id = 62` against `vocab_size = 32` is the out-of-bounds write described above.

</details>

## Tests

New file `tests/integration/test_draft_vocab_mapping_contract.py`, five cases:

- `test_default_d2t_is_the_offset_identity` for both drafts, asserting the engine formula recovers `arange`.
- `test_default_d2t_stays_inside_the_target_vocabulary` for both drafts with a reduced draft vocabulary.
- `test_generated_mapping_round_trips_through_the_offset_convention` pins the convention against `process_token_dict_to_mappings`, so the two producers cannot drift apart again.

Full CPU suite (`tests/integration tests/compat tests/config tests/examples`) run on both sides:

<details>
<summary>Test suite before/after</summary>

```
### BASELINE (origin/main, 333b754) ###
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DSPARK-veomni-npu-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DFLASH-veomni-npu-veomni_lm_head_sparse]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE3-veomni-cuda-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE1-fsdp-npu-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DOMINO-fsdp2-cuda-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_transfer_waits_after_actor_update
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_async_publish_sets_pending_ref_and_waits_before_next_publish
FAILED tests/integration/test_dspark_trainer_backend.py::test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names
FAILED tests/integration/test_verl_npu_vllm_compat.py::test_factory_fused_moe_survives_verl_npu_patch_import
9 failed, 245 passed, 2 warnings in 33.60s

### THIS BRANCH ###
(same 9 failures)
9 failed, 250 passed, 2 warnings in 21.26s
```

The same 9 tests fail on `main` and on this branch. They need optional dependencies (VeOmni, the NPU vLLM stack) that are absent in this environment, so they are pre-existing and unrelated. The `+5` on this branch are the new tests above.

</details>
