### PR TITLE
perf(eagle3): gate the drafter quality diagnostics on the log level

### DIFF
--- a/tests/integration/test_eagle3_diagnostics_gating_contract.py
+++ b/tests/integration/test_eagle3_diagnostics_gating_contract.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contract tests for the EAGLE-3 drafter quality diagnostics.
+
+They are log-only and every one of them forces a device sync, so they must not
+run on the hot path unless the log will actually be emitted.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+QUALITY_LOG_PREFIX = "[drafter logits quality]"
+BACKEND_LOGGER = "verl_speco.backends.eagle3_trainer_backend"
+
+
+def _backend_and_inputs():
+    import torch
+    from omegaconf import OmegaConf
+
+    from verl_speco.backends.eagle3_trainer_backend import Eagle3TrainerBackend
+
+    vocab_size, seq_len, ttt_length = 6, 4, 2
+
+    backend = Eagle3TrainerBackend(
+        OmegaConf.create(
+            {
+                "rollout": {
+                    "drafter": {"training": {"use_logits": False, "ttt_length": ttt_length}}
+                },
+                "model": {"path": "/tmp/none"},
+            }
+        ),
+        OmegaConf.create({}),
+    )
+    backend.target_model = lambda last_hidden: torch.zeros(
+        *last_hidden.shape[:-1], vocab_size
+    )
+
+    class _FakeDraft:
+        t2d = torch.ones(vocab_size, dtype=torch.bool)
+
+        def __call__(self, **kwargs):
+            return {
+                "logits": [
+                    torch.randn(1, seq_len, vocab_size) for _ in range(ttt_length)
+                ],
+                "position_masks": [
+                    torch.ones(1, seq_len) for _ in range(ttt_length)
+                ],
+            }
+
+    batch = {
+        "input_ids": torch.zeros(1, seq_len, dtype=torch.long),
+        "hidden_states": torch.zeros(1, seq_len, 8),
+        "last_hidden_states": torch.zeros(1, seq_len, 8),
+        "attention_mask": torch.ones(1, seq_len, dtype=torch.long),
+        "loss_mask": torch.ones(1, seq_len),
+        "position_ids": torch.arange(seq_len).unsqueeze(0),
+    }
+    return backend, _FakeDraft(), batch
+
+
+def test_quality_diagnostics_are_silent_above_debug(caplog) -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    backend, model, batch = _backend_and_inputs()
+    logging.getLogger(BACKEND_LOGGER).setLevel(logging.INFO)
+
+    with caplog.at_level(logging.DEBUG, logger=BACKEND_LOGGER):
+        backend.compute_loss(model, batch, 0)
+
+    assert not [r for r in caplog.records if QUALITY_LOG_PREFIX in r.getMessage()]
+
+
+def test_quality_diagnostics_are_emitted_at_debug(caplog) -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    backend, model, batch = _backend_and_inputs()
+    logging.getLogger(BACKEND_LOGGER).setLevel(logging.DEBUG)
+
+    try:
+        with caplog.at_level(logging.DEBUG, logger=BACKEND_LOGGER):
+            backend.compute_loss(model, batch, 0)
+    finally:
+        logging.getLogger(BACKEND_LOGGER).setLevel(logging.INFO)
+
+    quality_records = [
+        r for r in caplog.records if QUALITY_LOG_PREFIX in r.getMessage()
+    ]
+    assert quality_records
+    # Routine per-step training metrics belong at DEBUG, not WARNING.
+    assert all(r.levelno == logging.DEBUG for r in quality_records)
+
+
+def test_quality_diagnostics_do_not_sync_above_debug() -> None:
+    """Above DEBUG the loss must not pay for the diagnostics' device syncs."""
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    original_item = torch.Tensor.item
+
+    def run_at(level: int) -> int:
+        backend, model, batch = _backend_and_inputs()
+        logging.getLogger(BACKEND_LOGGER).setLevel(level)
+        calls = 0
+
+        def counting_item(self):
+            nonlocal calls
+            calls += 1
+            return original_item(self)
+
+        torch.Tensor.item = counting_item
+        try:
+            backend.compute_loss(model, batch, 0)
+        finally:
+            torch.Tensor.item = original_item
+            logging.getLogger(BACKEND_LOGGER).setLevel(logging.INFO)
+        return calls
+
+    assert run_at(logging.INFO) < run_at(logging.DEBUG)

--- a/tests/integration/test_eagle3_diagnostics_gating_contract.py
+++ b/tests/integration/test_eagle3_diagnostics_gating_contract.py
@@ -74,35 +74,49 @@ def _backend_and_inputs():
     return backend, _FakeDraft(), batch
 
 
-def test_quality_diagnostics_are_silent_above_debug(caplog) -> None:
-    pytest.importorskip("torch")
-    pytest.importorskip("transformers")
+class _Recorder(logging.Handler):
+    """Records everything the backend logger emits, whatever its level is.
 
+    ``caplog.at_level`` would raise the logger to DEBUG, which is exactly the
+    condition under test, so the handler is attached directly instead.
+    """
+
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def _compute_loss_at(level: int) -> list[logging.LogRecord]:
     backend, model, batch = _backend_and_inputs()
-    logging.getLogger(BACKEND_LOGGER).setLevel(logging.INFO)
-
-    with caplog.at_level(logging.DEBUG, logger=BACKEND_LOGGER):
-        backend.compute_loss(model, batch, 0)
-
-    assert not [r for r in caplog.records if QUALITY_LOG_PREFIX in r.getMessage()]
-
-
-def test_quality_diagnostics_are_emitted_at_debug(caplog) -> None:
-    pytest.importorskip("torch")
-    pytest.importorskip("transformers")
-
-    backend, model, batch = _backend_and_inputs()
-    logging.getLogger(BACKEND_LOGGER).setLevel(logging.DEBUG)
-
+    backend_logger = logging.getLogger(BACKEND_LOGGER)
+    previous_level = backend_logger.level
+    recorder = _Recorder()
+    backend_logger.setLevel(level)
+    backend_logger.addHandler(recorder)
     try:
-        with caplog.at_level(logging.DEBUG, logger=BACKEND_LOGGER):
-            backend.compute_loss(model, batch, 0)
+        backend.compute_loss(model, batch, 0)
     finally:
-        logging.getLogger(BACKEND_LOGGER).setLevel(logging.INFO)
+        backend_logger.removeHandler(recorder)
+        backend_logger.setLevel(previous_level)
+    return [r for r in recorder.records if QUALITY_LOG_PREFIX in r.getMessage()]
 
-    quality_records = [
-        r for r in caplog.records if QUALITY_LOG_PREFIX in r.getMessage()
-    ]
+
+def test_quality_diagnostics_are_silent_above_debug() -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    assert _compute_loss_at(logging.INFO) == []
+
+
+def test_quality_diagnostics_are_emitted_at_debug() -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    quality_records = _compute_loss_at(logging.DEBUG)
+
     assert quality_records
     # Routine per-step training metrics belong at DEBUG, not WARNING.
     assert all(r.levelno == logging.DEBUG for r in quality_records)
@@ -117,7 +131,9 @@ def test_quality_diagnostics_do_not_sync_above_debug() -> None:
 
     def run_at(level: int) -> int:
         backend, model, batch = _backend_and_inputs()
-        logging.getLogger(BACKEND_LOGGER).setLevel(level)
+        backend_logger = logging.getLogger(BACKEND_LOGGER)
+        previous_level = backend_logger.level
+        backend_logger.setLevel(level)
         calls = 0
 
         def counting_item(self):
@@ -130,7 +146,7 @@ def test_quality_diagnostics_do_not_sync_above_debug() -> None:
             backend.compute_loss(model, batch, 0)
         finally:
             torch.Tensor.item = original_item
-            logging.getLogger(BACKEND_LOGGER).setLevel(logging.INFO)
+            backend_logger.setLevel(previous_level)
         return calls
 
     assert run_at(logging.INFO) < run_at(logging.DEBUG)

--- a/verl_speco/backends/eagle3_trainer_backend.py
+++ b/verl_speco/backends/eagle3_trainer_backend.py
@@ -1178,6 +1178,10 @@ class Eagle3TrainerBackend:
             0.0, device=input_ids.device, dtype=torch.float32
         )
         gamma = 0.8
+        # The per-step quality stats below are log-only, and every one of them
+        # forces a device sync. Collect them only when the log will be emitted,
+        # matching how the EAGLE-1/2 backend gates the same diagnostics.
+        diagnostics_enabled = logger.isEnabledFor(logging.DEBUG)
 
         # Preprocess shifted targets
         for idx in range(length):
@@ -1234,7 +1238,7 @@ class Eagle3TrainerBackend:
                     position_mask=position_mask,
                 )
                 target_top1 = target_p.argmax(dim=-1)
-            if (
+            if diagnostics_enabled and (
                 base_valid_position.any()
                 and not valid_position[base_valid_position].all()
             ):
@@ -1244,7 +1248,7 @@ class Eagle3TrainerBackend:
                     int(dropped_tokens.detach().cpu().item()),
                 )
             with torch.no_grad():
-                if valid_position.any():
+                if diagnostics_enabled and valid_position.any():
                     draft_top1 = logits.argmax(dim=-1)
                     step_top1_correct = (
                         (draft_top1[valid_position] == target_top1[valid_position])
@@ -1303,7 +1307,11 @@ class Eagle3TrainerBackend:
             total_local_ploss += (gamma**idx) * step_loss_sum
             total_local_tokens += valid_position.float().sum()
 
-        if use_sparse_restricted_ce and sparse_base_tokens.detach().float().item() > 0:
+        if (
+            diagnostics_enabled
+            and use_sparse_restricted_ce
+            and sparse_base_tokens.detach().float().item() > 0
+        ):
             logger.debug(
                 "[drafter sparse restricted ce] base_tokens=%s valid_tokens=%s dropped=%s "
                 "intersection_mean=%.6f hit_mass_mean=%.6f min_intersection=%s min_hit_mass=%s",
@@ -1326,8 +1334,8 @@ class Eagle3TrainerBackend:
                 logits_sparse_min_mass,
             )
 
-        if quality_tokens.detach().float().item() > 0:
-            logger.warning(
+        if diagnostics_enabled and quality_tokens.detach().float().item() > 0:
+            logger.debug(
                 "[drafter logits quality] valid_tokens=%s top1_acc=%.6f top%s_acc=%.6f "
                 "local_ploss_sum=%.6f local_tokens=%s per_step=%s",
                 int(quality_tokens.detach().cpu().item()),


### PR DESCRIPTION
## Problem

`Eagle3TrainerBackend.compute_loss` collects per-step quality statistics unconditionally:

```python
with torch.no_grad():
    if valid_position.any():                       # sync
        ...
        quality_step_stats.append({
            "step": idx,
            "tokens": int(step_tokens.detach().cpu().item()),          # sync
            "top1": round(float((...).detach().cpu().item()), 6),      # sync
            f"top{quality_topk}": round(float((...).detach().cpu().item()), 6),  # sync
        })
...
if quality_tokens.detach().float().item() > 0:     # sync
    logger.warning(                                # six more syncs in the args
        "[drafter logits quality] ...",
    )
```

Every one of those runs on every microbatch, and the numbers are log-only: nothing in the returned loss dict reads `quality_top1_correct`, `quality_topk_correct`, `quality_tokens` or `quality_step_stats`. The non-finite-position check and the sparse-restricted-CE summary have the same shape.

The summary line is also at `WARNING`, so a normal training run emits one warning per step reporting routine metrics.

The EAGLE-1/2 backend already guards the identical diagnostics:

```python
# eagle1_trainer_backend.py
if logger.isEnabledFor(logging.DEBUG) and num_tokens.detach().item() > 0:
```

## Fix

Compute `diagnostics_enabled = logger.isEnabledFor(logging.DEBUG)` once before the TTT loop and gate the quality block, the non-finite-position log and the sparse-restricted-CE log on it, then move the summary line from `WARNING` to `DEBUG`.

Behaviour at `DEBUG` is unchanged.

## Validation

Ran a before/after repro on both `main` and this branch. It drives `compute_loss` with a stub draft at `INFO` and at `DEBUG`, counting `Tensor.item()` calls and recording what level the summary is emitted at.

<details>
<summary>Before/after repro output</summary>

```
=================== before: main (333b754) ===================
WARNING:[drafter logits quality] valid_tokens=7 top1_acc=0.142857 top5_acc=1.000000 local_ploss_sum=14.328695 local_tokens=7 per_step=[{'step': 0, 'tokens': 4, 'top1': 0.25, 'top5': 1.0}, {'step': 1, 'tokens': 3, 'top1': 0.0, 'top5': 1.0}]
WARNING:[drafter logits quality] valid_tokens=7 top1_acc=0.000000 top5_acc=1.000000 local_ploss_sum=12.494758 local_tokens=7 per_step=[{'step': 0, 'tokens': 4, 'top1': 0.0, 'top5': 1.0}, {'step': 1, 'tokens': 3, 'top1': 0.0, 'top5': 1.0}]
[one compute_loss call, ttt_length=2]
          at INFO : 12 Tensor.item() syncs, quality log = WARNING
          at DEBUG: 12 Tensor.item() syncs, quality log = WARNING

[verdict]
          diagnostics run at INFO too (12 syncs)
          summary line logs at WARNING
          RESULT: unconditional syncs on the hot path (bug present)

=================== after: this branch ===================
DEBUG:[drafter logits quality] valid_tokens=7 top1_acc=0.000000 top5_acc=1.000000 local_ploss_sum=12.494758 local_tokens=7 per_step=[{'step': 0, 'tokens': 4, 'top1': 0.0, 'top5': 1.0}, {'step': 1, 'tokens': 3, 'top1': 0.0, 'top5': 1.0}]
[one compute_loss call, ttt_length=2]
          at INFO : 0 Tensor.item() syncs, quality log = None
          at DEBUG: 12 Tensor.item() syncs, quality log = DEBUG

[verdict]
          diagnostics are skipped above DEBUG
          summary line logs at DEBUG
          RESULT: gated on the log level (fixed)
```

`ttt_length=2` here; the per-step part of that count grows with `ttt_length`.

</details>

## Tests

New file `tests/integration/test_eagle3_diagnostics_gating_contract.py`:

- `test_quality_diagnostics_are_silent_above_debug`
- `test_quality_diagnostics_are_emitted_at_debug`, which also pins the level at `DEBUG`
- `test_quality_diagnostics_do_not_sync_above_debug`, which counts `Tensor.item()` calls

The tests attach a handler to the backend logger directly rather than using `caplog.at_level`, because that helper raises the logger to `DEBUG` and would mask the exact condition under test.

Full CPU suite (`tests/integration tests/compat tests/config tests/examples`) run on both sides:

<details>
<summary>Test suite before/after</summary>

```
### BASELINE (origin/main, 333b754) ###
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DSPARK-veomni-npu-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DFLASH-veomni-npu-veomni_lm_head_sparse]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE3-veomni-cuda-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE1-fsdp-npu-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DOMINO-fsdp2-cuda-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_transfer_waits_after_actor_update
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_async_publish_sets_pending_ref_and_waits_before_next_publish
FAILED tests/integration/test_dspark_trainer_backend.py::test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names
FAILED tests/integration/test_verl_npu_vllm_compat.py::test_factory_fused_moe_survives_verl_npu_patch_import
9 failed, 245 passed, 2 warnings in 33.60s

### THIS BRANCH ###
(same 9 failures)
9 failed, 248 passed, 2 warnings in 21.11s
```

The same 9 tests fail on `main` and on this branch. They need optional dependencies (VeOmni, the NPU vLLM stack) that are absent in this environment, so they are pre-existing and unrelated. The `+3` on this branch are the new tests above.

</details>
