### PR TITLE
fix(peagle): validate the packed document lengths instead of reusing them per row

### DIFF
--- a/tests/integration/test_peagle_backend_contract.py
+++ b/tests/integration/test_peagle_backend_contract.py
@@ -294,6 +294,57 @@ def test_peagle_compute_loss_calls_the_module_forward() -> None:
     assert float(out["accuracy"]) == pytest.approx(0.75)
 
 
+def _peagle_training_model_and_batch(batch_size: int, seq_len: int, seq_lengths):
+    import torch
+
+    from verl_speco.backends.peagle_trainer_backend import PEagleTrainingModel
+    from verl_speco.models.peagle import LlamaForCausalLMPeagle
+
+    config = _tiny_peagle_config()
+    model = PEagleTrainingModel(
+        LlamaForCausalLMPeagle(config), num_depths=2, down_sample_ratio=0.5
+    )
+    kwargs = dict(
+        input_ids=torch.zeros(batch_size, seq_len, dtype=torch.long),
+        aux_hidden=torch.zeros(batch_size, seq_len, config.target_hidden_size * 3),
+        loss_mask=torch.ones(batch_size, seq_len),
+        attention_mask=torch.ones(batch_size, seq_len, dtype=torch.long),
+        target_logits=torch.zeros(batch_size, seq_len, config.vocab_size),
+        seq_lengths=seq_lengths,
+    )
+    return model, kwargs
+
+
+def test_peagle_rejects_packed_lengths_for_a_multi_row_batch() -> None:
+    """seq_lengths describes one packed sequence, so it cannot span rows.
+
+    The forward loops over the batch but applies the whole seq_lengths tensor to
+    every row, which would silently give row 1 row 0's document layout.
+    """
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    model, kwargs = _peagle_training_model_and_batch(
+        batch_size=2, seq_len=8, seq_lengths=torch.tensor([4, 4])
+    )
+
+    with pytest.raises(ValueError, match="single packed sequence"):
+        model(**kwargs)
+
+
+def test_peagle_rejects_packed_lengths_that_do_not_cover_the_sequence() -> None:
+    """A short seq_lengths silently turns the tail into unattendable padding."""
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    model, kwargs = _peagle_training_model_and_batch(
+        batch_size=1, seq_len=8, seq_lengths=torch.tensor([3, 2])
+    )
+
+    with pytest.raises(ValueError, match="sum to 5"):
+        model(**kwargs)
+
+
 def test_peagle_checkpoint_export_unwraps_the_training_model() -> None:
     pytest.importorskip("torch")
     from types import SimpleNamespace

--- a/verl_speco/backends/peagle_trainer_backend.py
+++ b/verl_speco/backends/peagle_trainer_backend.py
@@ -122,6 +122,25 @@ class PEagleTrainingModel(nn.Module):
 
         batch_size, seq_len = input_ids.shape
         device = input_ids.device
+        if seq_lengths is not None:
+            # seq_lengths is a flat list of document lengths for ONE packed
+            # sequence, which is what base_trainer builds for P-EAGLE. There is no
+            # per-row structure to index, so a multi-row batch would silently
+            # apply one row's document layout to all of them.
+            if batch_size > 1:
+                raise ValueError(
+                    "P-EAGLE seq_lengths describe a single packed sequence, but the batch "
+                    f"has {batch_size} rows; pack the documents into one row or drop seq_lengths"
+                )
+            # Any tail past sum(seq_lengths) gets document id -1 in the COD mask,
+            # which makes those queries attend to nothing at all rather than
+            # failing, so check the invariant instead of drafting on garbage.
+            total_length = int(seq_lengths.sum())
+            if total_length != seq_len:
+                raise ValueError(
+                    f"P-EAGLE seq_lengths sum to {total_length} but the packed sequence is "
+                    f"{seq_len} tokens long"
+                )
         loss_num = torch.zeros((), device=device, dtype=torch.float32)
         loss_den = torch.zeros((), device=device, dtype=torch.float32)
         correct = torch.zeros((), device=device, dtype=torch.float32)
@@ -137,9 +156,11 @@ class PEagleTrainingModel(nn.Module):
             )
             orig_positions = anchor_pos + depth
             if seq_lengths is not None:
-                row_length = seq_lengths.to(device)
+                document_lengths = seq_lengths.to(device)
             else:
-                row_length = attention_mask[b].sum().clamp_min(1).reshape(1).to(device)
+                document_lengths = (
+                    attention_mask[b].sum().clamp_min(1).reshape(1).to(device)
+                )
             loss_positions = row_loss_mask[0, orig_positions].bool()
 
             is_depth0 = depth == 0
@@ -161,7 +182,7 @@ class PEagleTrainingModel(nn.Module):
             block_mask = draft.build_peagle_block_mask(
                 anchor_pos=anchor_pos,
                 depth=depth,
-                lengths=row_length,
+                lengths=document_lengths,
                 total_seq_len=seq_len,
             )
             hidden = draft.forward_peagle(


### PR DESCRIPTION
## Problem

`seq_lengths` is a flat list of document lengths for **one** packed sequence. `base_trainer` builds it that way:

```python
batch["seq_lengths"] = torch.tensor(
    [chunk.size(0) for chunk in input_id_chunks], dtype=torch.long, device=dev
)
```

The P-EAGLE forward loops over the batch but hands the whole tensor to every row:

```python
for b in range(batch_size):
    ...
    if seq_lengths is not None:
        row_length = seq_lengths.to(device)          # not indexed by b
    else:
        row_length = attention_mask[b].sum()...      # this branch does index by b
```

Two gaps:

1. A multi-row batch would silently give every row row zero's document layout. `base_trainer` always produces a single flat row today, so this is latent, but the loop is written for `batch_size > 1` and the fallback branch does index per row.
2. Nothing checks that the lengths cover the sequence. The COD mask builds `document_ids` from `seq_lengths` and pads the remainder with `-1`:

```python
document_ids = torch.cat([document_ids, torch.full((total_seq_len - document_ids.shape[0],), -1, ...)])
...
is_not_padding = document_ids[q_anchor_pos] != -1
```

so any tail past `sum(seq_lengths)` becomes a query that attends to **nothing at all**. That is not an error, it is a silently degenerate attention row that still flows into the loss.

## Fix

Reject both, and rename the local to `document_lengths`, which is what the mask consumes.

The length check costs one comparison per forward on a path that already synchronizes several times (`generate_cod_sample_indices` and `create_block_mask` both do).

## Validation

Ran a before/after repro on both `main` and this branch, feeding the training model each malformed shape.

<details>
<summary>Before/after repro output</summary>

```
=================== before: main (333b754) ===================
[batch of 2 rows, seq_lengths=[4, 4] for an 8-token sequence]
          ACCEPTED (drafted on a mismatched document layout)

[1 row of 8 tokens, seq_lengths=[3, 2] covers only 5]
          ACCEPTED (drafted on a mismatched document layout)

[verdict]
          RESULT: 2 of 2 accepted silently (bug present)

=================== after: this branch ===================
[batch of 2 rows, seq_lengths=[4, 4] for an 8-token sequence]
          REJECTED: P-EAGLE seq_lengths describe a single packed sequence, but the batch has 2 rows; pack the documents into one row or drop seq_lengths

[1 row of 8 tokens, seq_lengths=[3, 2] covers only 5]
          REJECTED: P-EAGLE seq_lengths sum to 5 but the packed sequence is 8 tokens long

[verdict]
          RESULT: malformed packed lengths are rejected (fixed)
```

</details>

## Tests

Two new tests in `tests/integration/test_peagle_backend_contract.py`:

- `test_peagle_rejects_packed_lengths_for_a_multi_row_batch`
- `test_peagle_rejects_packed_lengths_that_do_not_cover_the_sequence`

Full CPU suite (`tests/integration tests/compat tests/config tests/examples`) run on both sides:

<details>
<summary>Test suite before/after</summary>

```
### BASELINE (origin/main, 333b754) ###
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DSPARK-veomni-npu-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DFLASH-veomni-npu-veomni_lm_head_sparse]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE3-veomni-cuda-veomni_lm_head_full]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[EAGLE1-fsdp-npu-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_sync_defers_for_all_lm_head_drafters[DOMINO-fsdp2-cuda-engine_full_param]
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_target_head_transfer_waits_after_actor_update
FAILED tests/integration/test_drafter_runtime_control_contract.py::test_async_publish_sets_pending_ref_and_waits_before_next_publish
FAILED tests/integration/test_dspark_trainer_backend.py::test_dspark_checkpoint_preserves_source_config_and_vllm_weight_names
FAILED tests/integration/test_verl_npu_vllm_compat.py::test_factory_fused_moe_survives_verl_npu_patch_import
9 failed, 245 passed, 2 warnings in 33.60s

### THIS BRANCH ###
(same 9 failures)
9 failed, 247 passed, 2 warnings in 23.06s
```

The same 9 tests fail on `main` and on this branch. They need optional dependencies (VeOmni, the NPU vLLM stack) that are absent in this environment, so they are pre-existing and unrelated. The `+2` on this branch are the new tests above.

</details>
