### PR TITLE
Feat(megatron): EAGLE3 drafter training on Megatron backend

### DIFF
--- a/.github/workflows/npu_vllm_unit_tests.yml
+++ b/.github/workflows/npu_vllm_unit_tests.yml
@@ -110,6 +110,7 @@ jobs:
       matrix:
         include:
           - drafter: eagle3
+          - drafter: megatron-eagle3
           - drafter: dflash
           - drafter: dspark
 
@@ -150,7 +151,7 @@ jobs:
           SPECO_DSPARK_DRAFT_MODEL: ${{ inputs.dspark_draft_model || env.SPECO_DEFAULT_DSPARK_DRAFT_MODEL }}
         run: |
           case "${{ matrix.drafter }}" in
-            eagle3)
+            eagle3|megatron-eagle3)
               draft_model="${SPECO_EAGLE3_DRAFT_MODEL}"
               ;;
             dflash)

--- a/.github/workflows/npu_vllm_unit_tests.yml
+++ b/.github/workflows/npu_vllm_unit_tests.yml
@@ -109,10 +109,10 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - drafter: eagle3
+          - drafter: megatron-eagle3
             enable_training: true
             disable_eagle3_torch_compile: true
-          - drafter: megatron-eagle3
+          - drafter: eagle3
             enable_training: true
             disable_eagle3_torch_compile: true
           - drafter: dflash

--- a/ci/run_example_test.sh
+++ b/ci/run_example_test.sh
@@ -154,8 +154,6 @@ overrides=(
   "trainer.n_gpus_per_node=${accelerator_count}"
   "actor_rollout_ref.rollout.tensor_model_parallel_size=${tensor_parallel_size}"
   "actor_rollout_ref.rollout.drafter.vllm.draft_tensor_parallel_size=${SPECO_DRAFT_TENSOR_PARALLEL_SIZE:-${tensor_parallel_size}}"
-  "actor_rollout_ref.actor.ulysses_sequence_parallel_size=${sequence_parallel_size}"
-  "actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sequence_parallel_size}"
   "data.train_batch_size=${SPECO_TRAIN_BATCH_SIZE:-1}"
   "data.max_prompt_length=${SPECO_MAX_PROMPT_LENGTH:-256}"
   "data.max_response_length=${SPECO_MAX_RESPONSE_LENGTH:-64}"
@@ -189,6 +187,13 @@ overrides=(
   "actor_rollout_ref.rollout.drafter.training.hidden_state_window_min_rows=${hidden_state_window_min_rows}"
   "actor_rollout_ref.rollout.drafter.training.hidden_state_window_tokens_per_sample=${hidden_state_window_tokens_per_sample}"
 )
+
+if [[ "${drafter}" != "megatron-eagle3" ]]; then
+  overrides+=(
+    "actor_rollout_ref.actor.ulysses_sequence_parallel_size=${sequence_parallel_size}"
+    "actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sequence_parallel_size}"
+  )
+fi
 
 if [[ "${drafter}" == "dflash" ]]; then
   overrides+=(

--- a/ci/run_example_test.sh
+++ b/ci/run_example_test.sh
@@ -24,6 +24,9 @@ case "${platform}/${backend}/${drafter}" in
   npu/vllm/eagle3)
     example="examples/run_qwen3-8b_drafter_eagle3_vllm_npu.sh"
     ;;
+  npu/vllm/megatron-eagle3)
+    example="examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh"
+    ;;
   npu/vllm/dflash)
     example="examples/run_qwen3-8b_drafter_dflash_vllm_npu.sh"
     ;;
@@ -37,7 +40,7 @@ case "${platform}/${backend}/${drafter}" in
     example="examples/run_qwen3-8b_drafter_dflash_sglang.sh"
     ;;
   *)
-    echo "usage: $0 {gpu|npu} {vllm|sglang} {eagle3|dflash|dspark}" >&2
+    echo "usage: $0 {gpu|npu} {vllm|sglang} {eagle3|megatron-eagle3|dflash|dspark}" >&2
     exit 2
     ;;
 esac
@@ -56,7 +59,7 @@ for name in "${required_vars[@]}"; do
 done
 
 case "${drafter}" in
-  eagle3)
+  eagle3|megatron-eagle3)
     draft_model="${SPECO_EAGLE3_DRAFT_MODEL:-}"
     draft_algorithm="EAGLE3"
     ;;

--- a/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm.sh
+++ b/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm.sh
@@ -1,0 +1,113 @@
+set -x
+
+case "${LD_PRELOAD:-}" in
+    *libjemalloc*) ;;
+    *)
+        if [ -f /usr/lib/aarch64-linux-gnu/libjemalloc.so.2 ]; then
+            export LD_PRELOAD="/usr/lib/aarch64-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:$LD_PRELOAD}"
+        elif [ -f /usr/lib64/libjemalloc.so.2 ]; then
+            export LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:$LD_PRELOAD}"
+        fi
+        ;;
+esac
+export MALLOC_CONF="${MALLOC_CONF:-narenas:8,thp:never,metadata_thp:disabled,dirty_decay_ms:0,muzzy_decay_ms:0}"
+export SPECO_JEMALLOC_RECLAIM_MODE="${SPECO_JEMALLOC_RECLAIM_MODE:-purge}"
+export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-2}"
+export MALLOC_TRIM_THRESHOLD_="${MALLOC_TRIM_THRESHOLD_:-131072}"
+
+
+
+project_name='verl_grpo_megatron_eagle3_drafter'
+exp_name='qwen3_4b_eagle3_drafter_megatron_vllm'
+
+
+gen_tp=1
+actor_tp=4
+actor_pp=1
+ppo_gpus_per_node=${SPECO_ACCELERATOR_COUNT:-4}
+ray_num_cpus=${SPECO_RAY_NUM_CPUS:-64}
+ray_worker_soft_limit=${SPECO_RAY_WORKER_SOFT_LIMIT:-8}
+
+
+MODEL_PATH=/path/to/model
+CKPTS_DIR=/path/to/checkpoint
+TRAIN_FILE=/path/to/train_file
+TEST_FILE=/path/to/test_file
+DRAFTER_PATH=/path/to/drafter
+
+
+PYTHONUNBUFFERED=1 python3 -m verl_speco.main \
+    algorithm.adv_estimator=grpo \
+    transfer_queue.enable=False \
+    data.train_files=${TRAIN_FILE} \
+    data.val_files=${TEST_FILE} \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=8192 \
+    data.filter_overlong_prompts=False \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=${MODEL_PATH} \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.calculate_entropy=False \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.enable_prefix_caching=True \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.n=2 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.strategy=megatron \
+    actor_rollout_ref.ref.megatron.param_offload=True \
+    actor_rollout_ref.rollout.drafter.enable=True \
+    actor_rollout_ref.rollout.drafter.enable_drafter_training=True \
+    actor_rollout_ref.rollout.drafter.model_path=${DRAFTER_PATH} \
+    actor_rollout_ref.rollout.drafter.speculative_algorithm="EAGLE3" \
+    actor_rollout_ref.rollout.drafter.training.collect_hidden_states_from_old_logprob=True \
+    actor_rollout_ref.rollout.drafter.training.old_logprob_hidden_capture_impl=forward_hook \
+    actor_rollout_ref.rollout.drafter.training.use_logits=False \
+    actor_rollout_ref.rollout.drafter.rollout.spec_steps=3 \
+    actor_rollout_ref.rollout.drafter.rollout.spec_topk=1 \
+    actor_rollout_ref.rollout.drafter.rollout.spec_verify_tokens=4 \
+    actor_rollout_ref.rollout.drafter.training.step=20 \
+    actor_rollout_ref.rollout.drafter.training.collect_interval_steps=1 \
+    actor_rollout_ref.rollout.drafter.training.training_interval_steps=1 \
+    actor_rollout_ref.rollout.drafter.training.publish_async=True \
+    actor_rollout_ref.rollout.drafter.training.publish_dtype=bf16 \
+    actor_rollout_ref.rollout.drafter.training.draft_update_weights_bucket_megabytes=512 \
+    actor_rollout_ref.rollout.drafter.training.draft_update_pause_generation=True \
+    actor_rollout_ref.rollout.drafter.training.draft_update_flush_before=False \
+    actor_rollout_ref.rollout.drafter.training.draft_update_flush_after=True \
+    actor_rollout_ref.rollout.load_format="auto" \
+    model_engine=megatron \
+    actor_rollout_ref.actor.strategy=megatron \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${actor_tp} \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${actor_pp} \
+    actor_rollout_ref.actor.megatron.sequence_parallel=True \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.sequence_parallel=True \
+    actor_rollout_ref.actor.megatron.param_offload=True \
+    actor_rollout_ref.actor.megatron.grad_offload=True \
+    actor_rollout_ref.actor.megatron.optimizer_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.val_before_train=False \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console"]' \
+    trainer.project_name=${project_name} \
+    trainer.experiment_name=${exp_name} \
+    trainer.n_gpus_per_node=${ppo_gpus_per_node} \
+    trainer.nnodes=1 \
+    trainer.save_freq=20 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=15 $@

--- a/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh
+++ b/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh
@@ -1,7 +1,7 @@
 set -x
 export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
 export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
-export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export TORCH_COMPILE_DISABLE=1
 export ASCEND_RT_VISIBLE_DEVICES="${ASCEND_RT_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
 case "${LD_PRELOAD:-}" in
     *libjemalloc*) ;;
@@ -28,8 +28,8 @@ project_name='verl_grpo_megatron_eagle3_drafter'
 exp_name='qwen3_4b_eagle3_drafter_megatron_vllm_npu'
 
 gen_tp=2
-actor_tp=4
-actor_pp=2
+actor_tp=8
+actor_pp=1
 ppo_gpus_per_node=${SPECO_ACCELERATOR_COUNT:-8}
 ray_num_cpus=${SPECO_RAY_NUM_CPUS:-64}
 ray_worker_soft_limit=${SPECO_RAY_WORKER_SOFT_LIMIT:-8}

--- a/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh
+++ b/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh
@@ -27,12 +27,21 @@ export HCCL_OP_EXPANSION_MOD=AIV
 project_name='verl_grpo_megatron_eagle3_drafter'
 exp_name='qwen3_4b_eagle3_drafter_megatron_vllm_npu'
 
-gen_tp=2
-actor_tp=8
-actor_pp=1
 ppo_gpus_per_node=${SPECO_ACCELERATOR_COUNT:-8}
+gen_tp=${SPECO_TENSOR_PARALLEL_SIZE:-2}
+actor_tp=${SPECO_MEGATRON_TENSOR_PARALLEL_SIZE:-${ppo_gpus_per_node}}
+actor_pp=${SPECO_MEGATRON_PIPELINE_PARALLEL_SIZE:-1}
 ray_num_cpus=${SPECO_RAY_NUM_CPUS:-64}
 ray_worker_soft_limit=${SPECO_RAY_WORKER_SOFT_LIMIT:-8}
+
+if (( ppo_gpus_per_node < 1 || actor_tp < 1 || actor_pp < 1 )); then
+    echo "SPECO_ACCELERATOR_COUNT, Megatron TP, and Megatron PP must all be positive" >&2
+    exit 2
+fi
+if (( ppo_gpus_per_node % (actor_tp * actor_pp) != 0 )); then
+    echo "SPECO_ACCELERATOR_COUNT=${ppo_gpus_per_node} must be divisible by Megatron TP x PP (${actor_tp} x ${actor_pp})" >&2
+    exit 2
+fi
 
 MODEL_PATH=/path/to/model
 CKPTS_DIR=/path/to/checkpoint

--- a/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh
+++ b/examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh
@@ -1,0 +1,121 @@
+set -x
+export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+export ASCEND_RT_VISIBLE_DEVICES="${ASCEND_RT_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+case "${LD_PRELOAD:-}" in
+    *libjemalloc*) ;;
+    *)
+        if [ -f /usr/lib/aarch64-linux-gnu/libjemalloc.so.2 ]; then
+            export LD_PRELOAD="/usr/lib/aarch64-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:$LD_PRELOAD}"
+        elif [ -f /usr/lib64/libjemalloc.so.2 ]; then
+            export LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:$LD_PRELOAD}"
+        fi
+        ;;
+esac
+export MALLOC_CONF="${MALLOC_CONF:-narenas:8,thp:never,metadata_thp:disabled,dirty_decay_ms:0,muzzy_decay_ms:0}"
+export SPECO_JEMALLOC_RECLAIM_MODE="${SPECO_JEMALLOC_RECLAIM_MODE:-purge}"
+export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-2}"
+export MALLOC_TRIM_THRESHOLD_="${MALLOC_TRIM_THRESHOLD_:-131072}"
+
+# NOTE: do NOT set PYTORCH_NPU_ALLOC_CONF=expandable_segments:True — vLLM-Ascend
+# CaMemAllocator asserts it is incompatible with the memory pool.
+export STREAMS_PER_DEVICE=32
+export HCCL_OP_EXPANSION_MOD=AIV
+
+
+project_name='verl_grpo_megatron_eagle3_drafter'
+exp_name='qwen3_4b_eagle3_drafter_megatron_vllm_npu'
+
+gen_tp=2
+actor_tp=4
+actor_pp=2
+ppo_gpus_per_node=${SPECO_ACCELERATOR_COUNT:-8}
+ray_num_cpus=${SPECO_RAY_NUM_CPUS:-64}
+ray_worker_soft_limit=${SPECO_RAY_WORKER_SOFT_LIMIT:-8}
+
+MODEL_PATH=/path/to/model
+CKPTS_DIR=/path/to/checkpoint
+TRAIN_FILE=/path/to/train_file
+TEST_FILE=/path/to/test_file
+DRAFTER_PATH=/path/to/drafter
+
+PYTHONUNBUFFERED=1 python3 -m verl_speco.main \
+    algorithm.adv_estimator=grpo \
+    transfer_queue.enable=False \
+    ray_kwargs.ray_init.num_cpus=${ray_num_cpus} \
+    +ray_kwargs.ray_init._system_config.prestart_worker_first_driver=false \
+    +ray_kwargs.ray_init._system_config.num_workers_soft_limit=${ray_worker_soft_limit} \
+    data.train_files=${TRAIN_FILE} \
+    data.val_files=${TEST_FILE} \
+    data.train_batch_size=64 \
+    data.max_prompt_length=512 \
+    data.max_response_length=8192 \
+    data.filter_overlong_prompts=False \
+    data.truncation='error' \
+    actor_rollout_ref.model.path=${MODEL_PATH} \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=10 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.calculate_entropy=False \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=20 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.enable_prefix_caching=True \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
+    actor_rollout_ref.rollout.n=5 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=20 \
+    actor_rollout_ref.ref.strategy=megatron \
+    actor_rollout_ref.ref.megatron.param_offload=True \
+    actor_rollout_ref.rollout.drafter.enable=True \
+    actor_rollout_ref.rollout.drafter.enable_drafter_training=True \
+    actor_rollout_ref.rollout.drafter.model_path=${DRAFTER_PATH} \
+    actor_rollout_ref.rollout.drafter.speculative_algorithm="EAGLE3" \
+    actor_rollout_ref.rollout.drafter.training.collect_hidden_states_from_old_logprob=True \
+    actor_rollout_ref.rollout.drafter.training.old_logprob_hidden_capture_impl=forward_hook \
+    actor_rollout_ref.rollout.drafter.training.use_logits=False \
+    actor_rollout_ref.rollout.drafter.rollout.spec_steps=3 \
+    actor_rollout_ref.rollout.drafter.rollout.spec_topk=1 \
+    actor_rollout_ref.rollout.drafter.rollout.spec_verify_tokens=4 \
+    actor_rollout_ref.rollout.drafter.training.step=20 \
+    actor_rollout_ref.rollout.drafter.training.collect_interval_steps=1 \
+    actor_rollout_ref.rollout.drafter.training.training_interval_steps=1 \
+    actor_rollout_ref.rollout.drafter.training.publish_async=True \
+    actor_rollout_ref.rollout.drafter.training.publish_dtype=bf16 \
+    actor_rollout_ref.rollout.drafter.training.draft_update_weights_bucket_megabytes=512 \
+    actor_rollout_ref.rollout.drafter.training.draft_update_pause_generation=True \
+    actor_rollout_ref.rollout.drafter.training.draft_update_flush_before=False \
+    actor_rollout_ref.rollout.drafter.training.draft_update_flush_after=True \
+    actor_rollout_ref.rollout.load_format="auto" \
+    model_engine=megatron \
+    actor_rollout_ref.actor.strategy=megatron \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${actor_tp} \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${actor_pp} \
+    actor_rollout_ref.actor.megatron.sequence_parallel=True \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.sequence_parallel=True \
+    actor_rollout_ref.actor.megatron.param_offload=True \
+    actor_rollout_ref.actor.megatron.grad_offload=True \
+    actor_rollout_ref.actor.megatron.optimizer_offload=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.val_before_train=False \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console"]' \
+    trainer.project_name=${project_name} \
+    trainer.experiment_name=${exp_name} \
+    trainer.n_gpus_per_node=${ppo_gpus_per_node} \
+    trainer.nnodes=1 \
+    trainer.default_local_dir=${CKPTS_DIR} \
+    trainer.save_freq=20 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=15 $@

--- a/tests/examples/test_ci_example_runner.py
+++ b/tests/examples/test_ci_example_runner.py
@@ -347,3 +347,32 @@ def test_example_runner_dry_run_covers_npu_dspark() -> None:
     assert "actor_rollout_ref.rollout.drafter.speculative_algorithm=DSPARK" in stdout
     assert "actor_rollout_ref.rollout.drafter.training.dspark_block_size=7" in stdout
     assert "actor_rollout_ref.rollout.drafter.rollout.spec_verify_tokens=7" in stdout
+
+
+def test_example_runner_dry_run_omits_ulysses_overrides_for_npu_megatron() -> None:
+    bash = _require_working_bash()
+    env = {
+        "SPECO_DRY_RUN": "true",
+        "SPECO_TARGET_MODEL": "/models/target",
+        "SPECO_EAGLE3_DRAFT_MODEL": "/models/eagle3",
+        "SPECO_TRAIN_FILE": "/data/train.parquet",
+        "SPECO_TEST_FILE": "/data/test.parquet",
+        "SPECO_CKPT_DIR": "/tmp/speco",
+        "SPECO_ACCELERATOR_COUNT": "8",
+    }
+    script = "".join(
+        f"export {name}={shlex.quote(value)}\n" for name, value in env.items()
+    )
+    script += _runner_script()
+    result = subprocess.run(
+        [bash, "-s", "--", "npu", "vllm", "megatron-eagle3"],
+        env=os.environ.copy(),
+        input=script.encode("utf-8"),
+        capture_output=True,
+        check=True,
+    )
+    stdout = result.stdout.decode("utf-8", errors="replace")
+
+    assert "example=examples/run_qwen3-4b_actor_megatron_drafter_eagle3_vllm_npu.sh" in stdout
+    assert "draft_algorithm=EAGLE3" in stdout
+    assert "ulysses_sequence_parallel_size" not in stdout

--- a/tests/examples/test_ci_example_runner.py
+++ b/tests/examples/test_ci_example_runner.py
@@ -117,7 +117,7 @@ def test_gpu_and_npu_workflows_run_examples_on_self_hosted_runners() -> None:
             "npu_vllm_unit_tests.yml",
             "npu",
             "vllm",
-            {"eagle3", "dflash", "dspark"},
+            {"eagle3", "megatron-eagle3", "dflash", "dspark"},
         ),
         ("npu_sglang_unit_tests.yml", "npu", "sglang", {"eagle3", "dflash"}),
     ):
@@ -146,7 +146,7 @@ def test_gpu_and_npu_workflows_run_examples_on_self_hosted_runners() -> None:
                 for entry in workflow["jobs"]["example"]["strategy"]["matrix"][
                     "include"
                 ]
-            } == {"eagle3", "dflash", "dspark"}
+            } == expected_drafters
             assert {
                 (entry["drafter"], entry["enable_training"])
                 for entry in workflow["jobs"]["example"]["strategy"]["matrix"][
@@ -154,6 +154,7 @@ def test_gpu_and_npu_workflows_run_examples_on_self_hosted_runners() -> None:
                 ]
             } == {
                 ("eagle3", "true"),
+                ("megatron-eagle3", "true"),
                 ("dflash", "true"),
                 ("dspark", "true"),
             }
@@ -164,6 +165,7 @@ def test_gpu_and_npu_workflows_run_examples_on_self_hosted_runners() -> None:
                 ]
             } == {
                 ("eagle3", "true"),
+                ("megatron-eagle3", "true"),
                 ("dflash", "false"),
                 ("dspark", "false"),
             }

--- a/tests/integration/test_oldlogprob_runtime_contract.py
+++ b/tests/integration/test_oldlogprob_runtime_contract.py
@@ -226,7 +226,7 @@ def test_unselected_flat_hidden_keeps_original_row_selection() -> None:
     torch.testing.assert_close(selected[1, 0], hidden[2])
 
 
-def test_cpu_transfer_tensor_detaches_and_copies_tensor_payload() -> None:
+def test_cpu_transfer_tensor_detaches_cpu_tensor_without_copy() -> None:
     torch = pytest.importorskip("torch")
     source = torch.tensor([1.0], requires_grad=True)
 
@@ -234,8 +234,24 @@ def test_cpu_transfer_tensor_detaches_and_copies_tensor_payload() -> None:
 
     assert transferred.device.type == "cpu"
     assert transferred.requires_grad is False
-    assert transferred.data_ptr() != source.data_ptr()
+    assert transferred.data_ptr() == source.data_ptr()
     torch.testing.assert_close(transferred, source.detach())
+
+
+def test_cpu_transfer_tensor_detaches_sparse_payload_rows() -> None:
+    torch = pytest.importorskip("torch")
+    payload = {
+        "rows": torch.tensor([[1.0]], requires_grad=True),
+        "batch_indices": [0],
+        "row_indices": [[0]],
+    }
+
+    transferred = _to_cpu_transfer_tensor(payload)
+
+    assert transferred["rows"].device.type == "cpu"
+    assert transferred["rows"].requires_grad is False
+    assert transferred["rows"].data_ptr() == payload["rows"].data_ptr()
+    assert transferred["batch_indices"] == [0]
 
 
 def test_forward_hook_rejects_malformed_selected_hidden() -> None:

--- a/tests/integration/test_oldlogprob_runtime_contract.py
+++ b/tests/integration/test_oldlogprob_runtime_contract.py
@@ -24,6 +24,7 @@ from verl_speco.integration.oldlogprob_runtime import (
     _find_layers_and_final_norm,
     _install_oldlogprob_fsdp_batch_postprocess_patch,
     _select_and_merge_concatenated_hidden,
+    _to_cpu_transfer_tensor,
     oldlogprob_hidden_runtime_enabled,
 )
 from verl_speco.integration.oldlogprob_layer_ids import (
@@ -223,6 +224,18 @@ def test_unselected_flat_hidden_keeps_original_row_selection() -> None:
     assert selected.shape == (2, 2, 2)
     torch.testing.assert_close(selected[0, 0], hidden[0])
     torch.testing.assert_close(selected[1, 0], hidden[2])
+
+
+def test_cpu_transfer_tensor_detaches_and_copies_tensor_payload() -> None:
+    torch = pytest.importorskip("torch")
+    source = torch.tensor([1.0], requires_grad=True)
+
+    transferred = _to_cpu_transfer_tensor(source)
+
+    assert transferred.device.type == "cpu"
+    assert transferred.requires_grad is False
+    assert transferred.data_ptr() != source.data_ptr()
+    torch.testing.assert_close(transferred, source.detach())
 
 
 def test_forward_hook_rejects_malformed_selected_hidden() -> None:

--- a/verl_speco/integration/oldlogprob_runtime.py
+++ b/verl_speco/integration/oldlogprob_runtime.py
@@ -42,6 +42,13 @@ OLD_LOGPROB_HIDDEN_STATES_KEY = "speco_oldlogprob_hidden_states"
 OLD_LOGPROB_HIDDEN_OBJECT_REF_KEY = "speco_oldlogprob_hidden_object_ref"
 OLD_LOGPROB_HIDDEN_REFS_KEY = "speco_oldlogprob_hidden_refs"
 OLD_LOGPROB_HIDDEN_REF_META_KEY = "speco_oldlogprob_hidden_ref_meta"
+# PP>1 single-put path: the last stage ray.put()s the concatenated hidden
+# tensor once (owner = last-stage process) and returns the ObjectRef here.
+# The task runner ray.get()s it once and releases the ref immediately so the
+# object does not pin the store.  Storing the ref (not the inline tensor) keeps
+# the RPC return value small and lets the big tensor be freed independently.
+OLD_LOGPROB_HIDDEN_WHOLE_REF_KEY = "speco_oldlogprob_hidden_whole_ref"
+OLD_LOGPROB_HIDDEN_WHOLE_REF_META_KEY = "speco_oldlogprob_hidden_whole_ref_meta"
 OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY = "speco_oldlogprob_hidden_chunk_refs"
 OLD_LOGPROB_HIDDEN_CHUNK_META_KEY = "speco_oldlogprob_hidden_chunk_meta"
 OLD_LOGPROB_AUX_LAYER_IDS_KEY = "speco_oldlogprob_aux_layer_ids"
@@ -58,6 +65,7 @@ _TIMING_RAY_PUT_US = 4
 _TIMING_WIDTH = 5
 
 _PATCHED = False
+_MEGATRON_PATCHED = False
 _BATCH_POSTPROCESS_PATCHED = False
 _BATCH_POSTPROCESS_PATCHED_MODULES: set[str] = set()
 _POSTPROCESS_PATCHED = False
@@ -518,7 +526,7 @@ def _put_oldlogprob_hidden_refs(
                 row_indices = row_indices_payload[sample_pos]
                 if row_indices is not None:
                     metas[batch_idx]["chunk_row_indices"] = row_indices
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.warning("Unable to export SPECO old-logprob hidden ObjectRefs: %s", exc)
         if (
             selected_is_sparse
@@ -575,24 +583,41 @@ def _install_oldlogprob_training_worker_postprocess_patch() -> bool:
     @wraps(postprocess_output)
     def speco_postprocess_output(self, output, *args, **kwargs):
         speco_non_tensor = {}
-        model_output = output.get("model_output") if isinstance(output, dict) else None
-        if isinstance(model_output, dict):
+        speco_tensor = {}
+        for source_dict in [
+            output.get("model_output") if isinstance(output, dict) else None,
+            output if isinstance(output, dict) else None,
+        ]:
+            if not isinstance(source_dict, dict):
+                continue
             for key in (
                 OLD_LOGPROB_HIDDEN_REFS_KEY,
                 OLD_LOGPROB_HIDDEN_REF_META_KEY,
                 OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY,
                 OLD_LOGPROB_HIDDEN_CHUNK_META_KEY,
+                OLD_LOGPROB_HIDDEN_WHOLE_REF_KEY,
+                OLD_LOGPROB_HIDDEN_WHOLE_REF_META_KEY,
             ):
-                if key in model_output:
-                    speco_non_tensor[key] = model_output.pop(key)
+                if key in source_dict and key not in speco_non_tensor:
+                    speco_non_tensor[key] = source_dict.pop(key)
+            for key in (
+                OLD_LOGPROB_HIDDEN_STATES_KEY,
+                OLD_LOGPROB_TIMING_KEY,
+                OLD_LOGPROB_SELECTED_BATCH_INDICES_KEY,
+            ):
+                if key in source_dict and key not in speco_tensor:
+                    speco_tensor[key] = source_dict.pop(key)
 
         final_output = postprocess_output(self, output, *args, **kwargs)
         if speco_non_tensor and final_output is not None:
             from verl.utils import tensordict_utils as tu
 
             for key, value in speco_non_tensor.items():
-                # These ObjectRef side-channel payloads use original sample indices and
-                # chunk-level metadata; they are not shaped like upstream tensor outputs.
+                tu.assign_non_tensor_data(final_output, key, value)
+        if speco_tensor and final_output is not None:
+            from verl.utils import tensordict_utils as tu
+
+            for key, value in speco_tensor.items():
                 tu.assign_non_tensor_data(final_output, key, value)
         return final_output
 
@@ -600,6 +625,153 @@ def _install_oldlogprob_training_worker_postprocess_patch() -> bool:
     worker_cls._speco_oldlogprob_patched_postprocess = True
     _POSTPROCESS_PATCHED = True
     logger.warning("SPECO old-logprob hidden ObjectRef postprocess patch active")
+
+    # Also patch postprocess_batch_func (aggregate_output) to pass through
+    # top-level SPECO keys that are stored OUTSIDE model_output by the
+    # Megatron postprocess patch (e.g. ObjectRef keys for sp_size > 1).
+    # aggregate_output normally only collects model_output/loss/metrics,
+    # discarding any other top-level keys.
+    try:
+        utils_module = importlib.import_module("verl.workers.engine.utils")
+        original_aggregate = getattr(utils_module, "postprocess_batch_func", None)
+        if callable(original_aggregate) and not getattr(
+            utils_module, "_speco_oldlogprob_patched_aggregate", False
+        ):
+            from functools import wraps as _wraps
+
+            @_wraps(original_aggregate)
+            def speco_aggregate_output(output_lst, indices, data):
+                result = original_aggregate(output_lst, indices, data)
+                if not isinstance(result, dict):
+                    return result
+
+                # Stash the micro-batch indices so the PP>1 post-schedule
+                # exchange can reorder its concatenated hidden tensor from
+                # micro-batch order to full-batch order (matching what this
+                # aggregate does for the PP=1 per-sample ObjectRef path).
+                if indices:
+                    result["_speco_microbatch_indices"] = indices
+
+                # Determine full-batch size from indices for ref remapping.
+                # indices is a list of lists: [[full_idx, ...], ...] per micro-batch.
+                full_batch_size = 0
+                if indices:
+                    for partition in indices:
+                        full_batch_size += len(partition)
+
+                # Merge ObjectRef keys across micro-batches.
+                # refs/metas are lists indexed by local batch_idx;
+                # remap to full-batch indices using `indices`.
+                refs_merged: list[Any] | None = None
+                metas_merged: list[Any] | None = None
+                chunk_refs_merged: list[Any] = []
+                chunk_meta_merged: list[Any] = []
+
+                for mb_idx, o in enumerate(output_lst):
+                    if not isinstance(o, dict):
+                        continue
+                    mb_indices = (
+                        indices[mb_idx] if (indices and mb_idx < len(indices)) else None
+                    )
+
+                    # refs and metas: remap local → full-batch
+                    refs = o.get(OLD_LOGPROB_HIDDEN_REFS_KEY)
+                    metas = o.get(OLD_LOGPROB_HIDDEN_REF_META_KEY)
+                    if (
+                        refs is not None
+                        and mb_indices is not None
+                        and isinstance(refs, (list, tuple))
+                    ):
+                        if refs_merged is None:
+                            refs_merged = [None] * full_batch_size
+                        for local_idx, full_idx in enumerate(mb_indices):
+                            if local_idx < len(refs) and full_idx < len(refs_merged):
+                                refs_merged[full_idx] = refs[local_idx]
+                    if (
+                        metas is not None
+                        and mb_indices is not None
+                        and isinstance(metas, (list, tuple))
+                    ):
+                        if metas_merged is None:
+                            metas_merged = [None] * full_batch_size
+                        for local_idx, full_idx in enumerate(mb_indices):
+                            if local_idx < len(metas) and full_idx < len(metas_merged):
+                                metas_merged[full_idx] = metas[local_idx]
+
+                    # chunk_refs: extend (chunks are independent across micro-batches)
+                    chunk_refs = o.get(OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY)
+                    if isinstance(chunk_refs, (list, tuple)):
+                        chunk_refs_merged.extend(chunk_refs)
+
+                    # chunk_meta: extend, remap sample_indices local→full-batch
+                    chunk_meta = o.get(OLD_LOGPROB_HIDDEN_CHUNK_META_KEY)
+                    if isinstance(chunk_meta, (list, tuple)):
+                        for cm in chunk_meta:
+                            if isinstance(cm, dict) and mb_indices is not None:
+                                si = cm.get("sample_indices") or []
+                                cm = dict(cm)  # copy to avoid mutating original
+                                cm["sample_indices"] = [
+                                    int(mb_indices[int(idx)])
+                                    if int(idx) < len(mb_indices)
+                                    else int(idx)
+                                    for idx in si
+                                ]
+                            chunk_meta_merged.append(cm)
+
+                if refs_merged is not None and any(r is not None for r in refs_merged):
+                    result[OLD_LOGPROB_HIDDEN_REFS_KEY] = refs_merged
+                if metas_merged is not None and any(
+                    m is not None for m in metas_merged
+                ):
+                    result[OLD_LOGPROB_HIDDEN_REF_META_KEY] = metas_merged
+                if chunk_refs_merged:
+                    result[OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY] = chunk_refs_merged
+                if chunk_meta_merged:
+                    result[OLD_LOGPROB_HIDDEN_CHUNK_META_KEY] = chunk_meta_merged
+
+                # For tensor keys (timing, selected_batch_indices): take first
+                for key in (
+                    OLD_LOGPROB_HIDDEN_STATES_KEY,
+                    OLD_LOGPROB_TIMING_KEY,
+                    OLD_LOGPROB_SELECTED_BATCH_INDICES_KEY,
+                ):
+                    if key in result:
+                        continue
+                    for o in output_lst:
+                        if isinstance(o, dict) and key in o and o[key] is not None:
+                            result[key] = o[key]
+                            break
+                return result
+
+            utils_module.postprocess_batch_func = speco_aggregate_output  # type: ignore[attr-defined]
+            utils_module._speco_oldlogprob_patched_aggregate = True  # type: ignore[attr-defined]
+
+            # Also patch the direct imports in each transformer_impl module.
+            # `from ..utils import postprocess_batch_func` creates a local
+            # binding that doesn't see the module-level patch above.
+            for mod_name in (
+                "verl.workers.engine.megatron.transformer_impl",
+                "verl.workers.engine.fsdp.transformer_impl",
+                "verl.workers.engine.automodel.transformer_impl",
+                "verl.workers.engine.torchtitan.transformer_impl",
+                "verl.workers.engine.veomni.transformer_impl",
+            ):
+                try:
+                    impl_mod = importlib.import_module(mod_name)
+                    if (
+                        getattr(impl_mod, "postprocess_batch_func", None)
+                        is original_aggregate
+                    ):
+                        impl_mod.postprocess_batch_func = speco_aggregate_output  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+
+            logger.warning("SPECO old-logprob aggregate_output patch active")
+    except Exception as exc:
+        logger.warning(
+            "Unable to install SPECO old-logprob aggregate_output patch: %s", exc
+        )
+
     return True
 
 
@@ -826,6 +998,8 @@ def _build_selection_context(
         sp_rank = 0
     object_ref_enabled = _oldlogprob_hidden_object_ref_enabled(micro_batch)
     compact_selected = bool(object_ref_enabled and sp_size <= 1)
+    if sp_size <= 1:
+        compact_selected = False
     sparse_sp_merge = bool(object_ref_enabled and sp_size > 1)
     selected_batch_indices = [
         int(batch_idx)
@@ -1075,8 +1249,19 @@ def _extract_hidden_tensor(module_output: Any):
         )
     if module_output is None:
         return None
-    if module_output.dim() == 3 and module_output.size(0) == 1:
-        return module_output.squeeze(0)
+    # Normalize to a 2D [total_tokens, hidden] tensor for packed
+    # (use_remove_padding, NO_PADDING) sequences.  HF transformer layers emit
+    # batch-first [1, seq, hidden]; mcore decoder layers emit seq-first
+    # [seq, 1, hidden].  Squeeze the singleton batch dim in either layout so
+    # the row-index selection (which assumes a flat packed sequence) lands on
+    # the correct token positions.  Without the seq-first branch, mcore's
+    # [seq, 1, hidden] stays 3D and the 3D selection path treats the seq dim
+    # as the batch dim, producing positionally-misaligned hidden states.
+    if module_output.dim() == 3:
+        if module_output.size(0) == 1:
+            module_output = module_output.squeeze(0)
+        elif module_output.size(1) == 1:
+            module_output = module_output.squeeze(1)
     return module_output
 
 
@@ -1461,7 +1646,7 @@ def _get_module_by_path(root: Any, path: str):
 
 
 def _find_layers_and_final_norm(engine: Any):
-    import torch.nn as nn
+    from torch import nn
 
     module = getattr(engine, "module", None)
     roots: list[Any] = []
@@ -1552,6 +1737,13 @@ def _cleanup_oldlogprob_hidden_capture(engine: Any) -> None:
             handle.remove()
         except Exception:  # noqa: BLE001
             pass
+    # Wait for any pending non-blocking isend work to complete before
+    # freeing the context (PP>1 cross-stage captures).
+    for work in context.pop("_pending_isend_works", []):
+        try:
+            work.wait()
+        except Exception:  # noqa: BLE001
+            pass
     try:
         delattr(engine, "_speco_oldlogprob_hidden_context")
     except AttributeError:
@@ -1627,13 +1819,34 @@ def _consume_oldlogprob_hidden_capture(engine: Any):
             required_keys.append(context["final_key"])
         missing = [key for key in required_keys if key not in captures]
         if missing:
-            raise RuntimeError(
-                f"SPECO old-logprob forward-hook capture missed hidden tensors: {missing}"
-            )
+            # For Megatron PP>1, cross-stage communication may have failed
+            # (e.g., HCCL port conflicts on NPU).  Skip missing keys instead
+            # of crashing; the drafter will train with fewer hidden states.
+            pp_size = context.get("pp_size", 1)
+            if pp_size > 1:
+                logger.warning(
+                    "SPECO old-logprob Megatron PP>1: skipping missing hidden "
+                    "tensors %s (cross-stage communication may have failed)",
+                    missing,
+                )
+            else:
+                raise RuntimeError(
+                    f"SPECO old-logprob forward-hook capture missed hidden tensors: {missing}"
+                )
 
-        hidden_parts = [captures[key] for key in context["aux_keys"]]
-        if context.get("final_key") is not None:
-            hidden_parts.append(captures[context["final_key"]])
+        # Only include keys that were actually captured (skip missing).
+        aux_keys_present = [k for k in context["aux_keys"] if k in captures]
+        hidden_parts = [captures[key] for key in aux_keys_present]
+        final_key = context.get("final_key")
+        if final_key is not None and final_key in captures:
+            hidden_parts.append(captures[final_key])
+        if not hidden_parts:
+            logger.warning(
+                "SPECO consume: no hidden parts to merge (captures empty); "
+                "capture_keys=%s required_keys=%s",
+                list(captures.keys()),
+                required_keys,
+            )
         selected, owner_mask = _select_and_merge_concatenated_hidden(
             context,
             hidden_parts,
@@ -1642,6 +1855,12 @@ def _consume_oldlogprob_hidden_capture(engine: Any):
         if _is_sparse_sp_non_source_context(context):
             return {}
         if selected is None:
+            logger.warning(
+                "SPECO consume: _select_and_merge_concatenated_hidden returned None; "
+                "hidden_parts=%d context_local_positions=%d",
+                len(hidden_parts),
+                len(context.get("local_positions", []) or []),
+            )
             return {}
         output = {
             OLD_LOGPROB_HIDDEN_STATES_KEY: selected,
@@ -1862,5 +2081,1005 @@ def install_oldlogprob_hidden_runtime_patch(
     logger.warning(
         "SPECO old-logprob hidden runtime patch active: actor_backend=%s",
         backend,
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Megatron backend support
+#
+# The FSDP patch above hooks ``FSDPEngineWithLMHead.prepare_model_inputs`` /
+# ``prepare_model_outputs`` because the HF transformers model exposes
+# ``output_hidden_states=True`` and named sub-modules (``model.layers``,
+# ``model.norm``).  The Megatron (mcore) engine has a different module layout
+# (``decoder.layers``, ``decoder.final_layernorm``, ``output_layer``) and the
+# model instance is passed to ``forward_step`` as an argument rather than
+# living on ``self.module``.  We therefore patch ``forward_step`` to install
+# forward hooks on the mcore decoder layers / final-layernorm before the model
+# forward, and patch ``postprocess_micro_batch_func`` to consume the captured
+# hidden tensors after the forward returns.
+# ---------------------------------------------------------------------------
+
+
+def _find_megatron_layers_and_final_norm(engine: Any, model: Any):
+    """Find mcore decoder layers and final layernorm for hidden-state capture.
+
+    Returns ``(layers, final_norm)`` where *layers* is a plain ``list`` of
+    ``nn.Module`` and *final_norm* is the ``nn.Module`` for the decoder's
+    final layernorm (or ``None`` if not found).
+    """
+    from torch import nn
+
+    roots: list[Any] = []
+    # The model passed to forward_step is typically DDP/FSDP wrapped; unwrap
+    # the .module chain to reach the GPTModel.
+    unwrapped = _unwrap_module(model)
+    for root in (unwrapped, _unwrap_module(unwrapped)):
+        if root is not None and all(root is not existing for existing in roots):
+            roots.append(root)
+
+    # Also try engine.module (list of pipeline-stage models) as a fallback.
+    engine_module = getattr(engine, "module", None)
+    if isinstance(engine_module, (list, tuple)):
+        for stage in engine_module:
+            stage_unwrapped = _unwrap_module(stage)
+            if stage_unwrapped is not None and all(
+                stage_unwrapped is not existing for existing in roots
+            ):
+                roots.append(stage_unwrapped)
+    elif engine_module is not None:
+        eu = _unwrap_module(engine_module)
+        if eu is not None and all(eu is not existing for existing in roots):
+            roots.append(eu)
+
+    # mcore GPTModel layout: decoder.layers + decoder.final_layernorm
+    for root in roots:
+        layers = _get_module_by_path(root, "decoder.layers")
+        if isinstance(layers, (nn.ModuleList, list, tuple)) and len(layers) > 0:
+            final_norm = _get_module_by_path(root, "decoder.final_layernorm")
+            if final_norm is not None:
+                return list(layers), final_norm
+
+    # Fallback: search named_modules for a ModuleList ending in "layers" or "h"
+    # and a sibling norm module.  This covers mcore variants that use different
+    # attribute names.
+    for root in roots:
+        for name, child in root.named_modules():
+            if not isinstance(child, (nn.ModuleList, list, tuple)) or len(child) <= 0:
+                continue
+            if not (name.endswith("layers") or name.endswith("h")):
+                continue
+            parent_path = name.rsplit(".", 1)[0] if "." in name else ""
+            norm_names = ("final_layernorm", "final_layer_norm", "norm", "ln_f")
+            for norm_name in norm_names:
+                norm_path = f"{parent_path}.{norm_name}" if parent_path else norm_name
+                final_norm = _get_module_by_path(root, norm_path)
+                if final_norm is not None:
+                    return list(child), final_norm
+            return list(child), None
+
+    return None, None
+
+
+def _megatron_mpu():
+    """Return the Megatron parallel_state module or None."""
+    try:
+        from megatron.core import parallel_state as mpu
+    except Exception:  # noqa: BLE001
+        return None
+    return mpu
+
+
+def _build_megatron_selection_context(
+    engine: Any, model: Any, micro_batch: Any
+) -> dict[str, Any]:
+    """Build the hidden-state selection context for the Megatron engine.
+
+    This mirrors :func:`_build_selection_context` but resolves sequence-parallel
+    information from Megatron's ``mpu`` (tensor-model-parallel group) instead of
+    the FSDP Ulysses SP group.  When TP>1 and ``sequence_parallel=True`` (the
+    mcore default for TP>1), the hidden states from decoder-layer and
+    final-layernorm hooks are SP-sharded: each TP rank holds
+    ``ceil(total_tokens / TP)`` rows.  The existing ``_flat_local_range`` /
+    ``_merge_sp_selected`` machinery then handles local selection and
+    cross-rank gathering.
+    """
+    import torch
+    from verl.utils import tensordict_utils as tu
+    from verl.utils.dataset.dataset_utils import DatasetPadMode
+
+    use_remove_padding = tu.get_non_tensor_data(
+        data=micro_batch, key="use_remove_padding", default=True
+    )
+    pad_mode = tu.get_non_tensor_data(
+        data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING
+    )
+    if not use_remove_padding or pad_mode != DatasetPadMode.NO_PADDING:
+        raise NotImplementedError(
+            "SPECO old-logprob hidden collection currently requires use_remove_padding=True "
+            "and DatasetPadMode.NO_PADDING"
+        )
+
+    input_ids = micro_batch["input_ids"]
+    collect_mask = micro_batch[OLD_LOGPROB_COLLECT_MASK_KEY].bool()
+    hidden_positions = micro_batch[OLD_LOGPROB_HIDDEN_POSITIONS_KEY].long()
+    hidden_position_mask = micro_batch[OLD_LOGPROB_HIDDEN_POSITION_MASK_KEY].bool()
+    offsets = input_ids.offsets().to(device=hidden_positions.device, dtype=torch.long)
+    total_tokens = int(input_ids.values().numel())
+    # Use actual micro-batch size from offsets, not from hidden_positions.
+    # When use_remove_padding=True, the dispatch may not split
+    # hidden_positions/collect_mask (regular tensors in a packed batch),
+    # so hidden_positions.shape[0] may be the full batch size.
+    actual_batch_size = int(offsets.size(0) - 1)
+    full_batch_size = hidden_positions.size(0)
+    if full_batch_size > actual_batch_size:
+        collect_mask = collect_mask[:actual_batch_size]
+        hidden_positions = hidden_positions[:actual_batch_size]
+        hidden_position_mask = hidden_position_mask[:actual_batch_size]
+    batch_size = actual_batch_size
+    hidden_rows = hidden_positions.size(1)
+
+    # Resolve Megatron SP information.
+    mpu = _megatron_mpu()
+    sp_group = None
+    sp_size = 1
+    sp_rank = 0
+    pad_size = 0
+    if mpu is not None and mpu.is_initialized():
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        # Check if native SP is actually enabled. Two sources:
+        # 1. The user's config passed through the micro_batch (most reliable,
+        #    because MindSpeed repatch may override tf_config.sequence_parallel)
+        # 2. The transformer config (fallback)
+        _sp_disabled = False
+        try:
+            _sp_disabled = bool(micro_batch.get("speco_oldlogprob_sp_disabled", False))
+            if hasattr(_sp_disabled, "data"):
+                _sp_disabled = bool(_sp_disabled.data)
+        except Exception:
+            _sp_disabled = False
+        if not _sp_disabled:
+            _tf_config = getattr(engine, "tf_config", None)
+            _sp_disabled = not getattr(_tf_config, "sequence_parallel", True)
+        if tp_size > 1 and not _sp_disabled:
+            sp_group = mpu.get_tensor_model_parallel_group()
+            sp_size = tp_size
+            sp_rank = mpu.get_tensor_model_parallel_rank()
+            # The packed (thd) sequence is padded to be divisible by TP size
+            # before scatter_to_sequence_parallel_region splits it.
+            pad_size = (sp_size - total_tokens % sp_size) % sp_size
+
+    # When SP is disabled (sp_size=1), each participating rank has the full
+    # hidden state.  We must NOT use the TP group for all_reduce, because
+    # non-participating ranks won't call the collective → deadlock.
+    # Set sp_group=None so _merge_sp_selected skips all_reduce.
+    if sp_size <= 1:
+        sp_group = None
+
+    # When sp_size=1, keep object_ref mode enabled so hidden states are
+    # stored as Ray ObjectRefs (avoids memory exhaustion from large tensors
+    # being serialized through the TensorDict pipeline).  The
+    # speco_aggregate_output patch merges refs across micro-batches.
+    object_ref_enabled = _oldlogprob_hidden_object_ref_enabled(micro_batch)
+
+    # Also resolve PP rank for cross-stage capture ordering.
+    pp_rank = 0
+    pp_size = 1
+    is_last_stage = True
+    if mpu is not None and mpu.is_initialized():
+        pp_size = mpu.get_pipeline_model_parallel_world_size()
+        pp_rank = mpu.get_pipeline_model_parallel_rank()
+        is_last_stage = mpu.is_pipeline_last_stage(ignore_virtual=True)
+
+    compact_selected = bool(object_ref_enabled and sp_size <= 1)
+    if sp_size <= 1:
+        compact_selected = False
+    sparse_sp_merge = bool(object_ref_enabled and sp_size > 1)
+    selected_batch_indices = [
+        int(batch_idx)
+        for batch_idx in range(int(batch_size))
+        if bool(collect_mask[batch_idx].item())
+        and bool(hidden_position_mask[batch_idx].detach().any().item())
+    ]
+    selected_index_by_batch = {
+        batch_idx: selected_idx
+        for selected_idx, batch_idx in enumerate(selected_batch_indices)
+    }
+    output_batch_size = (
+        len(selected_batch_indices) if compact_selected else int(batch_size)
+    )
+    rank_start, rank_end = _flat_local_range(total_tokens, pad_size, sp_size, sp_rank)
+
+    local_positions = []
+    local_batch_indices = []
+    local_row_indices = []
+    local_3d_batch_indices = []
+    local_3d_seq_positions = []
+    selected_owner_rows: dict[int, list[int]] = {}
+    for batch_idx in range(batch_size):
+        if not bool(collect_mask[batch_idx].item()):
+            continue
+        if compact_selected:
+            output_batch_idx = selected_index_by_batch.get(
+                int(batch_idx), int(batch_idx)
+            )
+        else:
+            output_batch_idx = int(batch_idx)
+        seq_start = int(offsets[batch_idx].item())
+        seq_end = int(offsets[batch_idx + 1].item())
+        for row_idx in range(hidden_rows):
+            if not bool(hidden_position_mask[batch_idx, row_idx].item()):
+                continue
+            seq_pos = int(hidden_positions[batch_idx, row_idx].item())
+            if seq_pos < 0:
+                continue
+            global_flat_pos = seq_start + seq_pos
+            if global_flat_pos < seq_start or global_flat_pos >= seq_end:
+                continue
+            if global_flat_pos < rank_start or global_flat_pos >= rank_end:
+                continue
+            local_pos = global_flat_pos - rank_start
+            local_positions.append(local_pos)
+            local_batch_indices.append(output_batch_idx)
+            local_row_indices.append(row_idx)
+            local_3d_batch_indices.append(int(batch_idx))
+            local_3d_seq_positions.append(seq_pos)
+            selected_owner_rows.setdefault(output_batch_idx, []).append(row_idx)
+
+    return {
+        "batch_size": int(batch_size),
+        "output_batch_size": int(output_batch_size),
+        "compact_selected": bool(compact_selected),
+        "sparse_sp_merge": bool(sparse_sp_merge),
+        "selected_batch_indices": selected_batch_indices,
+        "hidden_rows": int(hidden_rows),
+        "local_positions": local_positions,
+        "local_batch_indices": local_batch_indices,
+        "local_row_indices": local_row_indices,
+        "local_3d_batch_indices": local_3d_batch_indices,
+        "local_3d_seq_positions": local_3d_seq_positions,
+        "max_local_position": max(local_positions, default=-1),
+        "selected_owner_rows": selected_owner_rows,
+        "sp_group": sp_group,
+        "sp_size": sp_size,
+        "sp_rank": sp_rank,
+        "pp_rank": pp_rank,
+        "pp_size": pp_size,
+        "is_last_stage": is_last_stage,
+        "total_tokens": total_tokens,
+        "pad_size": pad_size,
+        "timing_us": {
+            "select": 0.0,
+            "sp_merge": 0.0,
+            "concat": 0.0,
+        },
+    }
+
+
+def _megatron_map_aux_layers_to_stage(
+    aux_layer_ids: list[int],
+    num_local_layers: int,
+    pp_rank: int,
+    pp_size: int,
+    num_global_layers: int,
+) -> list[tuple[str, int | None]]:
+    """Map global aux layer IDs to (kind, local_index) on the current PP stage.
+
+    Returns a list aligned with *aux_layer_ids*.  Each entry is either:
+    - ``("layer", local_index)`` — the layer is on this stage.
+    - ``("final", None)`` — the layer maps to the final layernorm (only on the
+      last stage when the global index equals ``num_global_layers - 1``).
+    - ``("skip", None)`` — the layer is on a different PP stage.
+    """
+    num_layers_per_stage = num_global_layers // pp_size
+    remainder = num_global_layers % pp_size
+    stage_start = pp_rank * num_layers_per_stage + min(pp_rank, remainder)
+    stage_end = stage_start + num_layers_per_stage + (1 if pp_rank < remainder else 0)
+
+    results: list[tuple[str, int | None]] = []
+    for layer_id in aux_layer_ids:
+        index = int(layer_id)
+        if index == num_global_layers - 1:
+            # Final layer maps to final_layernorm on the last stage.
+            if pp_rank == pp_size - 1:
+                results.append(("final", None))
+            else:
+                results.append(("skip", None))
+        elif stage_start <= index < stage_end:
+            local_index = index - stage_start
+            results.append(("layer", local_index))
+        else:
+            results.append(("skip", None))
+    return results
+
+
+def _install_megatron_hidden_hooks(engine: Any, model: Any, micro_batch: Any) -> None:
+    """Install forward hooks on mcore decoder layers / final-layernorm.
+
+    Supports TP>1 (Megatron native sequence parallelism) and PP>1 (pipeline
+    parallelism).  For PP>1, only layers on the current pipeline stage are
+    hooked; captures from non-last stages are communicated to the last stage
+    via ``dist`` on the PP group.
+    """
+    if not _tensor_key_present(micro_batch, OLD_LOGPROB_COLLECT_MASK_KEY):
+        return
+
+    layers, final_norm = _find_megatron_layers_and_final_norm(engine, model)
+    if not layers:
+        raise RuntimeError(
+            "SPECO old-logprob Megatron forward-hook capture could not find transformer layers"
+        )
+
+    selection_context = _build_megatron_selection_context(engine, model, micro_batch)
+    pp_rank = selection_context["pp_rank"]
+    pp_size = selection_context["pp_size"]
+    is_last_stage = selection_context["is_last_stage"]
+
+    aux_layer_ids = _oldlogprob_aux_layer_ids_from_batch(micro_batch)
+    hidden_layout = _oldlogprob_hidden_layout(micro_batch)
+
+    # Determine the global number of layers.  With PP>1 each stage only has
+    # a subset; the global count is stored in the engine's model config or
+    # can be derived from the tf_config.
+    num_global_layers = len(aux_layer_ids)  # fallback
+    tf_config = getattr(engine, "tf_config", None)
+    if tf_config is not None:
+        cfg_num_layers = getattr(tf_config, "num_layers", None)
+        if cfg_num_layers is not None:
+            num_global_layers = int(cfg_num_layers)
+
+    # Map global aux layer IDs to this stage.
+    stage_mapping = _megatron_map_aux_layers_to_stage(
+        aux_layer_ids, len(layers), pp_rank, pp_size, num_global_layers
+    )
+
+    aux_keys: list[str] = []
+    required_modules: dict[str, Any] = {}
+    stage_capture_keys: list[str] = []  # keys captured on this stage
+    for layer_id, (kind, local_index) in zip(
+        aux_layer_ids, stage_mapping, strict=False
+    ):
+        global_key = f"aux:{layer_id}"
+        if kind == "final":
+            if final_norm is None:
+                raise RuntimeError(
+                    "SPECO old-logprob Megatron forward-hook capture could not find final norm module"
+                )
+            aux_keys.append(global_key)
+            required_modules[global_key] = final_norm
+            stage_capture_keys.append(global_key)
+        elif kind == "layer":
+            aux_keys.append(global_key)
+            required_modules[global_key] = layers[local_index]
+            stage_capture_keys.append(global_key)
+        else:
+            # "skip" — the layer is on a different PP stage.
+            aux_keys.append(global_key)
+
+    final_key: str | None = None
+    if hidden_layout in {"eagle3_aux_plus_last", "dflash_aux_plus_last"}:
+        if final_norm is not None:
+            final_key = "final"
+            required_modules[final_key] = final_norm
+            stage_capture_keys.append(final_key)
+        elif not is_last_stage:
+            # The final hidden state will be communicated from the last stage.
+            # On non-last stages we skip it; the last stage captures it.
+            pass
+        else:
+            raise RuntimeError(
+                "SPECO old-logprob Megatron forward-hook capture could not find final norm module"
+            )
+
+    _cleanup_oldlogprob_hidden_capture(engine)
+
+    context: dict[str, Any] = {
+        **selection_context,
+        "aux_keys": aux_keys,
+        "final_key": final_key,
+        "hidden_layout": hidden_layout,
+        "captures": {},
+        "handles": [],
+        "stage_capture_keys": stage_capture_keys,
+        "num_global_layers": num_global_layers,
+    }
+    for key, module in required_modules.items():
+        context["handles"].append(
+            module.register_forward_hook(_make_capture_hook(context, key))
+        )
+    engine._speco_oldlogprob_hidden_context = context
+
+
+def _speco_pp_exchange_dir() -> str:
+    """Resolve the PP cross-stage hidden-state exchange temp dir.
+
+    These are transient per-step pickle files written by non-last PP stages and
+    read+removed by the last stage within one ``forward_backward_batch`` call.
+    The writer and reader are different processes, so the dir must be
+    deterministic and node-local (single-node PP, ``nnodes=1``).
+
+    Priority:
+      1. ``SPECO_PP_EXCHANGE_DIR`` env override (caller/user controls it).
+      2. ``/dev/shm/speco_pp_exchange`` when ``/dev/shm`` is writable — a
+         RAM-backed dir keeps potentially-large transient pickles off real
+         disk so they cannot fill it.
+      3. The platform temp dir (``tempfile.gettempdir()``, honors ``TMPDIR``)
+         as a portable fallback for systems without ``/dev/shm``.
+    """
+    env = os.environ.get("SPECO_PP_EXCHANGE_DIR")
+    if env:
+        return env
+    shm = "/dev/shm"
+    if os.path.isdir(shm) and os.access(shm, os.W_OK):
+        return os.path.join(shm, "speco_pp_exchange")
+    import tempfile
+
+    return os.path.join(tempfile.gettempdir(), "speco_pp_exchange")
+
+
+def _megatron_post_stage_exchange_and_consume(engine: Any, losses_reduced: Any) -> None:
+    """Post-schedule: exchange captures across PP stages via Ray object store
+    + temp files (completely avoids HCCL dist communication).
+
+    Non-last PP stages pickle their CPU captures directly to a temp file.
+    The last stage polls for the files, loads them, merges into saved
+    contexts, then consumes.  Uses pure file I/O — no Ray object store
+    (avoids blocking the WorkerDict async actor's event loop) and no
+    HCCL dist communication (avoids NPU P2P/broadcast issues).
+    """
+    context = getattr(engine, "_speco_oldlogprob_hidden_context", None)
+    if not context:
+        logger.debug(
+            "SPECO PP exchange: no hidden context on a rank; hooks may not have fired"
+        )
+        return
+    pp_size = int(context.get("pp_size", 1) or 1)
+    if pp_size <= 1:
+        return
+
+    import os
+    import pickle
+    import time
+
+    import torch
+
+    mpu = _megatron_mpu()
+    if mpu is None:
+        return
+    pp_rank = mpu.get_pipeline_model_parallel_rank()
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    is_last_stage = pp_rank == pp_size - 1
+    # When SP=True each TP rank holds a different shard of the hidden states,
+    # so ALL TP ranks must participate in the temp-file exchange and the
+    # subsequent SP all-reduce inside _consume_oldlogprob_hidden_capture.
+    # When SP=False all TP ranks have identical captures, so only tp_rank=0
+    # does I/O (avoids a multi-way file write race).
+    sp_size = int(context.get("sp_size", 1) or 1)
+    is_io_rank = True if sp_size > 1 else (tp_rank == 0)
+
+    stage_captures = getattr(engine, "_speco_pp_stage_captures", [])
+    saved_contexts = getattr(engine, "_speco_pp_saved_contexts", [])
+
+    # Use a unique temp dir per engine instance
+    tmp_dir = _speco_pp_exchange_dir()
+    os.makedirs(tmp_dir, exist_ok=True)
+    # Tag includes tp_rank when SP=True (each TP rank has different captures).
+    tag = f"fbb_tp{tp_rank}" if sp_size > 1 else "fbb"
+
+    if not is_last_stage and is_io_rank:
+        # Non-last stage: pickle CPU captures directly to a file (no ray.put/get
+        # to avoid blocking the Ray actor's event loop).
+        # Skip writing an empty file: a stale empty file from a non-collect
+        # call (e.g. ref log_prob with a leftover context) would be read by
+        # the next old_log_prob's last stage instead of the real captures.
+        if not stage_captures or not any(caps_mb for caps_mb in stage_captures):
+            pass  # skip writing an empty file
+        else:
+            cpu_caps = []
+            for caps_mb in stage_captures:
+                cpu_mb = {}
+                for k, v in caps_mb.items():
+                    if torch.is_tensor(v):
+                        cpu_mb[k] = v.detach().cpu().clone()
+                    elif _is_sparse_selected(v):
+                        cpu_mb[k] = {
+                            k2: (
+                                v2.detach().cpu().clone() if torch.is_tensor(v2) else v2
+                            )
+                            for k2, v2 in v.items()
+                        }
+                    else:
+                        cpu_mb[k] = v
+                cpu_caps.append(cpu_mb)
+            ref_path = os.path.join(tmp_dir, f"pp_{pp_rank}_{tag}.pkl")
+            tmp_path = ref_path + ".tmp"
+            try:
+                with open(tmp_path, "wb") as f:
+                    pickle.dump(cpu_caps, f)
+                os.rename(tmp_path, ref_path)
+            except Exception:
+                raise
+            logger.warning(
+                "SPECO PP exchange: stage pp_rank=%s wrote %d microbatch captures to %s",
+                pp_rank,
+                len(cpu_caps),
+                ref_path,
+            )
+
+    if is_last_stage and is_io_rank:
+        # Last stage: poll for non-last stages' files, load directly (no ray.get).
+        # With SP=True ALL TP ranks enter here (each reads its own tp_rank-tagged
+        # file), participate in the SP all-reduce inside consume, but only
+        # tp_rank=0 attaches the result to the output dict.
+        all_stage_captures = [None] * pp_size
+        all_stage_captures[pp_rank] = stage_captures
+
+        for src_rank in range(pp_size - 1):
+            ref_path = os.path.join(tmp_dir, f"pp_{src_rank}_{tag}.pkl")
+            # Poll for the file (non-last stage writes after its schedule)
+            for _ in range(300):  # 30s timeout
+                if os.path.exists(ref_path):
+                    break
+                time.sleep(0.1)
+            if not os.path.exists(ref_path):
+                logger.warning(
+                    "SPECO PP cross-stage: timed out waiting for stage %s captures",
+                    src_rank,
+                )
+                continue
+            try:
+                with open(ref_path, "rb") as f:
+                    stage_captures_from_src = pickle.load(f)
+            except Exception:
+                continue
+            all_stage_captures[src_rank] = stage_captures_from_src
+            try:
+                os.remove(ref_path)
+            except Exception:
+                pass
+            logger.warning(
+                "SPECO PP exchange: last stage loaded %d microbatch captures from stage %s",
+                len(stage_captures_from_src) if stage_captures_from_src else 0,
+                src_rank,
+            )
+
+        # Merge non-last stages' captures into saved contexts + consume.
+        # ALL io ranks do this (the consume includes the SP all-reduce when
+        # sp_size>1, which requires every TP rank to participate).
+        saved_contexts = getattr(engine, "_speco_pp_saved_contexts", [])
+        # Infer the runtime device from saved captures.  With SP=True the
+        # captures are sparse_selected dicts (not plain tensors), so look
+        # inside the "rows" field for the device.
+        device = torch.device("cpu")
+        for _ctx in saved_contexts:
+            _caps = _ctx.get("captures", {}) if isinstance(_ctx, dict) else {}
+            for _v in _caps.values():
+                _probe = _v
+                if _is_sparse_selected(_v):
+                    _probe = _v.get("rows")
+                if torch.is_tensor(_probe) and _probe.device.type != "cpu":
+                    device = _probe.device
+                    break
+            else:
+                continue
+            break
+
+        if not saved_contexts:
+            logger.warning(
+                "SPECO PP exchange: last stage has %d saved contexts (empty!); "
+                "postprocess may not have run for PP>1",
+                len(saved_contexts),
+            )
+
+        all_hidden_outputs = []
+        for mb_idx in range(len(saved_contexts)):
+            saved_ctx = saved_contexts[mb_idx]
+            merged = saved_ctx.get("captures", {})
+            for stage in range(pp_size - 1):
+                stage_mbs = all_stage_captures[stage]
+                if stage_mbs and mb_idx < len(stage_mbs):
+                    for key, tensor in stage_mbs[mb_idx].items():
+                        if key not in merged:
+                            if torch.is_tensor(tensor):
+                                merged[key] = tensor.to(device).clone()
+                            elif _is_sparse_selected(tensor):
+                                # SP=True: captures are sparse dicts with inner
+                                # tensors.  Move them to the runtime device (they
+                                # were pickled to CPU for the temp-file exchange).
+                                merged[key] = {
+                                    k2: (
+                                        v2.to(device).clone()
+                                        if torch.is_tensor(v2)
+                                        else v2
+                                    )
+                                    for k2, v2 in tensor.items()
+                                }
+                            else:
+                                merged[key] = tensor
+            saved_ctx["captures"] = merged
+            engine._speco_oldlogprob_hidden_context = saved_ctx
+
+            hidden_output = _consume_oldlogprob_hidden_capture(engine)
+            if hidden_output:
+                # With SP=True the consume returns a sparse_selected dict
+                # (not a plain tensor).  Convert to dense so the single-put
+                # + reorder + task-runner inline path handles it uniformly.
+                hs = hidden_output.get(OLD_LOGPROB_HIDDEN_STATES_KEY)
+                if _is_sparse_selected(hs):
+                    hs = _dense_selected_from_sparse(saved_ctx, hs)
+                    hidden_output[OLD_LOGPROB_HIDDEN_STATES_KEY] = hs
+                all_hidden_outputs.append(hidden_output)
+            else:
+                if _is_sparse_sp_non_source_context(saved_ctx):
+                    logger.debug(
+                        "SPECO PP exchange: consume returned empty (SP non-source "
+                        "rank, expected) for mb_idx=%d",
+                        mb_idx,
+                    )
+                else:
+                    logger.warning(
+                        "SPECO PP exchange: consume returned empty for mb_idx=%d; "
+                        "merged capture keys=%s",
+                        mb_idx,
+                        list(merged.keys()),
+                    )
+
+        # Only tp_rank=0 attaches the result to the output dict.  Other TP
+        # ranks participated in the SP all-reduce above; their result is
+        # discarded (only tp_rank=0's output is returned by the worker).
+        if tp_rank != 0:
+            pass  # SP all-reduce done; nothing more to do
+        elif not all_hidden_outputs:
+            logger.warning(
+                "SPECO PP exchange: no hidden outputs produced (all consume empty); "
+                "losses_reduced type=%s",
+                type(losses_reduced).__name__,
+            )
+        elif not isinstance(losses_reduced, dict):
+            logger.warning(
+                "SPECO PP exchange: losses_reduced is not a dict (%s); "
+                "cannot attach hidden states",
+                type(losses_reduced).__name__,
+            )
+        else:
+            model_output = losses_reduced.setdefault("model_output", {})
+            if not isinstance(model_output, dict):
+                model_output = {}
+                losses_reduced["model_output"] = model_output
+
+            # Timing tensor is small; keep it inline.
+            timing_tensors = [
+                ho[OLD_LOGPROB_TIMING_KEY]
+                for ho in all_hidden_outputs
+                if OLD_LOGPROB_TIMING_KEY in ho
+                and torch.is_tensor(ho[OLD_LOGPROB_TIMING_KEY])
+            ]
+            if timing_tensors:
+                model_output[OLD_LOGPROB_TIMING_KEY] = (
+                    torch.cat(timing_tensors, dim=0)
+                    if len(timing_tensors) > 1
+                    else timing_tensors[0]
+                )
+
+            # Concatenate all microbatches' hidden states into one big tensor,
+            # then ray.put() ONCE.  Owner = this last-stage process, so the
+            # ObjectRef metadata is correct and any process can ray.get() it.
+            # The task runner ray.get()s it once and releases the ref, so the
+            # big tensor does not stay pinned in the object store (unlike the
+            # inline path, where it rides the RPC return and fills the store).
+            hs_tensors = [
+                ho[OLD_LOGPROB_HIDDEN_STATES_KEY]
+                for ho in all_hidden_outputs
+                if OLD_LOGPROB_HIDDEN_STATES_KEY in ho
+                and torch.is_tensor(ho[OLD_LOGPROB_HIDDEN_STATES_KEY])
+            ]
+            if hs_tensors:
+                big_tensor = (
+                    torch.cat(hs_tensors, dim=0)
+                    if len(hs_tensors) > 1
+                    else hs_tensors[0]
+                )
+
+                # Reorder dim-0 from micro-batch order to full-batch order.
+                # The per-microbatch hidden tensors are concatenated in
+                # micro-batch order, but the task runner indexes them by the
+                # full-batch batch_idx.  With use_dynamic_bsz the micro-batches
+                # are permuted, so without this reorder the hidden states are
+                # misaligned with the prompts/responses → the drafter trains on
+                # wrong data and acceptance degrades.  The PP=1 path gets this
+                # reorder for free via speco_aggregate_output's indices remap;
+                # PP>1 bypasses that aggregate, so we do it here.
+                mb_indices = losses_reduced.pop("_speco_microbatch_indices", None)
+                if mb_indices and big_tensor.dim() >= 1:
+                    try:
+                        # Flatten indices: position i in big_tensor (micro-batch
+                        # order) maps to full_idx in the full batch.
+                        flat_indices: list[int] = []
+                        for part in mb_indices:
+                            flat_indices.extend(int(x) for x in part)
+                        if len(flat_indices) == int(big_tensor.shape[0]):
+                            idx_tensor = torch.tensor(
+                                flat_indices, dtype=torch.long, device=big_tensor.device
+                            )
+                            reordered = torch.zeros_like(big_tensor)
+                            reordered.index_copy_(0, idx_tensor, big_tensor)
+                            big_tensor = reordered
+                    except Exception:
+                        pass
+
+                whole_ref = None
+                try:
+                    import ray as _ray
+
+                    whole_ref = _ray.put(big_tensor)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "SPECO PP exchange: single ray.put failed (%s); "
+                        "falling back to inline tensor (may raise object-store pressure)",
+                        exc,
+                    )
+                if whole_ref is not None:
+                    model_output[OLD_LOGPROB_HIDDEN_WHOLE_REF_KEY] = whole_ref
+                    model_output[OLD_LOGPROB_HIDDEN_WHOLE_REF_META_KEY] = {
+                        "shape": tuple(int(s) for s in big_tensor.shape),
+                        "dtype": str(big_tensor.dtype),
+                        "nbytes": int(big_tensor.nbytes),
+                        "num_samples": int(big_tensor.shape[0])
+                        if big_tensor.dim() >= 1
+                        else 0,
+                        "num_microbatches": len(all_hidden_outputs),
+                    }
+                    logger.warning(
+                        "SPECO PP exchange: put hidden states as single ObjectRef "
+                        "(shape=%s, %.1f MiB) from %d microbatch(s)",
+                        tuple(big_tensor.shape),
+                        big_tensor.nbytes / (1024 * 1024),
+                        len(all_hidden_outputs),
+                    )
+                else:
+                    model_output[OLD_LOGPROB_HIDDEN_STATES_KEY] = big_tensor
+            else:
+                logger.warning(
+                    "SPECO PP exchange: no hidden-state tensors to attach "
+                    "(all_hidden_outputs=%d)",
+                    len(all_hidden_outputs),
+                )
+
+            # Per-owner ObjectRefs are not produced for PP>1 (we skipped
+            # _put_oldlogprob_hidden_refs), so this merge is a no-op here;
+            # kept for parity with the PP=1 path.
+            refs_merged: list[Any] = []
+            metas_merged: list[Any] = []
+            for ho in all_hidden_outputs:
+                refs = ho.get(OLD_LOGPROB_HIDDEN_REFS_KEY)
+                metas = ho.get(OLD_LOGPROB_HIDDEN_REF_META_KEY)
+                if isinstance(refs, (list, tuple)):
+                    refs_merged.extend(refs)
+                if isinstance(metas, (list, tuple)):
+                    metas_merged.extend(metas)
+            if refs_merged:
+                losses_reduced[OLD_LOGPROB_HIDDEN_REFS_KEY] = refs_merged
+            if metas_merged:
+                losses_reduced[OLD_LOGPROB_HIDDEN_REF_META_KEY] = metas_merged
+
+    # Cleanup
+    engine._speco_pp_stage_captures = []
+    if hasattr(engine, "_speco_pp_saved_contexts"):
+        engine._speco_pp_saved_contexts = []
+    # Clear the hidden context so a subsequent forward_backward_batch without
+    # the collect mask (e.g. ref log_prob) does NOT enter the exchange with a
+    # stale context and write an empty temp file that the next step's
+    # old_log_prob would read instead of the real captures.
+    _cleanup_oldlogprob_hidden_capture(engine)
+
+
+def _megatron_save_stage_captures(engine: Any, micro_batch: Any) -> None:
+    """Save this PP stage's captures to engine storage for post-schedule aggregation.
+
+    Replaces the disabled P2P isend approach.  Each stage independently stores
+    its per-micro-batch captures; the post-schedule function
+    ``_megatron_post_stage_exchange_and_consume`` exchanges them via
+    ``dist.broadcast`` (collective, HCCL-safe) after the pipeline schedule.
+    """
+    context = getattr(engine, "_speco_oldlogprob_hidden_context", None)
+    if not context:
+        return
+    pp_size = int(context.get("pp_size", 1) or 1)
+    if pp_size <= 1:
+        return  # PP=1: no cross-stage exchange needed
+
+    import torch
+
+    captures = context.get("captures", {})
+    # Clone tensors so they survive the next micro-batch's context cleanup
+    saved = {}
+    for key, val in captures.items():
+        if torch.is_tensor(val):
+            saved[key] = val.detach().clone()
+        elif _is_sparse_selected(val):
+            saved[key] = {
+                k2: (v2.detach().clone() if torch.is_tensor(v2) else v2)
+                for k2, v2 in val.items()
+            }
+        else:
+            saved[key] = val
+
+    if not hasattr(engine, "_speco_pp_stage_captures"):
+        engine._speco_pp_stage_captures = []
+    engine._speco_pp_stage_captures.append(saved)
+
+
+def install_oldlogprob_hidden_runtime_patch_megatron() -> bool:
+    """Patch upstream Megatron LM-head engine methods in the current process.
+
+    This mirrors :func:`install_oldlogprob_hidden_runtime_patch` but targets
+    ``MegatronEngineWithLMHead`` (and its NPU subclass
+    ``MindspeedEngineWithLMHead`` which inherits all methods).  Because the
+    Megatron engine receives the model as an argument to ``forward_step``
+    rather than storing it on ``self.module`` as a single HF module, we patch
+    ``forward_step`` to install forward hooks on the model *before* the
+    original forward and ``postprocess_micro_batch_func`` to *consume* the
+    captured hidden tensors after the forward returns.
+    """
+    global _MEGATRON_PATCHED
+    if _MEGATRON_PATCHED:
+        _install_oldlogprob_training_worker_postprocess_patch()
+        return True
+
+    try:
+        module = importlib.import_module(
+            "verl.workers.engine.megatron.transformer_impl"
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Unable to install SPECO old-logprob Megatron patch: %s", exc)
+        return False
+
+    engine_cls = getattr(module, "MegatronEngineWithLMHead", None)
+    if engine_cls is None:
+        logger.warning(
+            "Unable to install SPECO old-logprob Megatron patch: missing MegatronEngineWithLMHead"
+        )
+        return False
+
+    forward_step = getattr(engine_cls, "forward_step", None)
+    postprocess = getattr(engine_cls, "postprocess_micro_batch_func", None)
+    if not callable(forward_step) or not callable(postprocess):
+        logger.warning(
+            "Unable to install SPECO old-logprob Megatron patch: missing engine methods"
+        )
+        return False
+
+    _install_oldlogprob_training_worker_postprocess_patch()
+
+    # --- Patch forward_step: install hooks before the model forward ---------
+    if not getattr(
+        engine_cls, "_speco_oldlogprob_megatron_patched_forward_step", False
+    ):
+        import itertools
+
+        @wraps(forward_step)
+        def speco_megatron_forward_step(
+            self,
+            batch_iter,
+            model,
+            logits_processor_func,
+            postprocess_micro_batch_func,
+        ):
+            # Peek at the batch to detect SPECO collect-mask without
+            # consuming it; put it back via itertools.chain so the
+            # original forward_step sees the same iterator.
+            batch = next(batch_iter)
+            batch_iter = itertools.chain([batch], batch_iter)
+
+            has_collect = _tensor_key_present(batch, OLD_LOGPROB_COLLECT_MASK_KEY)
+            if has_collect:
+                _install_megatron_hidden_hooks(self, model, batch)
+
+            result = forward_step(
+                self,
+                batch_iter,
+                model,
+                logits_processor_func,
+                postprocess_micro_batch_func,
+            )
+
+            if has_collect:
+                _megatron_save_stage_captures(self, batch)
+
+            return result
+
+        engine_cls.forward_step = speco_megatron_forward_step
+        engine_cls._speco_oldlogprob_megatron_patched_forward_step = True
+
+    # --- Patch postprocess_micro_batch_func: consume captured hidden --------
+    if not getattr(engine_cls, "_speco_oldlogprob_megatron_patched_postprocess", False):
+
+        @wraps(postprocess)
+        def speco_megatron_postprocess(self, output, data, *args, **kwargs):
+            result = postprocess(self, output, data, *args, **kwargs)
+
+            context = getattr(self, "_speco_oldlogprob_hidden_context", None)
+            if context:
+                _ctx_pp_size = int(context.get("pp_size", 1) or 1)
+                if _ctx_pp_size > 1:
+                    # PP>1: defer consume to post-schedule exchange.
+                    # Save this (last stage) context for later merge + consume.
+                    import torch as _torch
+
+                    _saved_captures = {}
+                    for _k, _v in context.get("captures", {}).items():
+                        _saved_captures[_k] = (
+                            _v.detach().clone() if _torch.is_tensor(_v) else _v
+                        )
+                    _saved_ctx = dict(context)
+                    _saved_ctx["captures"] = _saved_captures
+                    if not hasattr(self, "_speco_pp_saved_contexts"):
+                        self._speco_pp_saved_contexts = []
+                    self._speco_pp_saved_contexts.append(_saved_ctx)
+                else:
+                    # PP=1: consume immediately (existing behavior)
+                    hidden_output = _consume_oldlogprob_hidden_capture(self)
+                    if hidden_output and isinstance(result, tuple) and len(result) == 2:
+                        _ctx_sp_size = int(context.get("sp_size", 1) or 1)
+                        hidden_output = _put_oldlogprob_hidden_refs(hidden_output, data)
+                        scaled_loss, output_dict = result
+                        if isinstance(output_dict, dict):
+                            import torch as _torch
+
+                            model_output = output_dict.setdefault("model_output", {})
+                            if not isinstance(model_output, dict):
+                                model_output = {}
+                                output_dict["model_output"] = model_output
+                            for k, v in hidden_output.items():
+                                if k == OLD_LOGPROB_HIDDEN_STATES_KEY:
+                                    if _torch.is_tensor(v):
+                                        model_output[k] = v
+                                    elif _is_sparse_selected(v):
+                                        output_dict[k] = v
+                                elif k == OLD_LOGPROB_TIMING_KEY and _torch.is_tensor(
+                                    v
+                                ):
+                                    model_output[k] = v
+                                elif k in (
+                                    OLD_LOGPROB_HIDDEN_REFS_KEY,
+                                    OLD_LOGPROB_HIDDEN_REF_META_KEY,
+                                    OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY,
+                                    OLD_LOGPROB_HIDDEN_CHUNK_META_KEY,
+                                ):
+                                    output_dict[k] = v
+                        return scaled_loss, output_dict
+
+            # When sp_size=1 and SP is disabled, hidden states are only on
+            # participating ranks (those that called forward_step).  The
+            # source rank may not have called forward_step, so its
+            # model_output lacks hidden states.  This is handled later by
+            # the task runner via a separate collection path.
+
+            return result
+
+        engine_cls.postprocess_micro_batch_func = speco_megatron_postprocess
+        engine_cls._speco_oldlogprob_megatron_patched_postprocess = True
+
+    # --- Patch forward_backward_batch: post-schedule cross-stage exchange ---
+    if not getattr(engine_cls, "_speco_oldlogprob_megatron_patched_fbb", False):
+        original_fbb = engine_cls.forward_backward_batch
+
+        @wraps(original_fbb)
+        def speco_megatron_forward_backward_batch(
+            self, data, loss_function, forward_only=False
+        ):
+            result = original_fbb(self, data, loss_function, forward_only)
+            # After the pipeline schedule completes, exchange captures across
+            # PP stages via dist.broadcast (collective, HCCL-safe) and consume
+            # on the last stage.  No-op for PP=1.
+            _megatron_post_stage_exchange_and_consume(self, result)
+            return result
+
+        engine_cls.forward_backward_batch = speco_megatron_forward_backward_batch
+        engine_cls._speco_oldlogprob_megatron_patched_fbb = True
+
+    _MEGATRON_PATCHED = True
+    logger.warning(
+        "SPECO old-logprob hidden runtime patch active for upstream Megatron LM-head engine"
     )
     return True

--- a/verl_speco/integration/oldlogprob_runtime.py
+++ b/verl_speco/integration/oldlogprob_runtime.py
@@ -235,6 +235,25 @@ def _selected_device(selected: Any):
     return selected.device
 
 
+def _to_cpu_transfer_tensor(value: Any):
+    """Detach tensors before sending SPECO side-channel data through Ray.
+
+    ``DataProto.non_tensor_batch`` is serialized by Ray as a Python payload.
+    It must therefore never contain an accelerator-resident tensor: the
+    receiving task runner deliberately owns no accelerator resources.  Drafter
+    workers move collected features back to their local device before training.
+    """
+
+    try:
+        import torch
+
+        if torch.is_tensor(value):
+            return value.detach().to(device="cpu", copy=True).contiguous()
+    except Exception:  # noqa: BLE001
+        pass
+    return value
+
+
 def _row_indices_payload(row_indices: Any):
     if row_indices is None:
         return None
@@ -618,7 +637,12 @@ def _install_oldlogprob_training_worker_postprocess_patch() -> bool:
             from verl.utils import tensordict_utils as tu
 
             for key, value in speco_tensor.items():
-                tu.assign_non_tensor_data(final_output, key, value)
+                # These values cross a Ray boundary in non_tensor_data.  Keep
+                # that side channel CPU-only so a CPU-only TaskRunner can
+                # deserialize GPU, NPU, and other accelerator worker outputs.
+                tu.assign_non_tensor_data(
+                    final_output, key, _to_cpu_transfer_tensor(value)
+                )
         return final_output
 
     worker_cls._postprocess_output = speco_postprocess_output
@@ -2755,10 +2779,15 @@ def _megatron_post_stage_exchange_and_consume(engine: Any, losses_reduced: Any) 
                 and torch.is_tensor(ho[OLD_LOGPROB_TIMING_KEY])
             ]
             if timing_tensors:
-                model_output[OLD_LOGPROB_TIMING_KEY] = (
+                timing = (
                     torch.cat(timing_tensors, dim=0)
                     if len(timing_tensors) > 1
                     else timing_tensors[0]
+                )
+                # Timing follows the same non-tensor Ray side channel as
+                # hidden-state metadata after worker postprocessing.
+                model_output[OLD_LOGPROB_TIMING_KEY] = _to_cpu_transfer_tensor(
+                    timing
                 )
 
             # Concatenate all microbatches' hidden states into one big tensor,
@@ -2806,6 +2835,11 @@ def _megatron_post_stage_exchange_and_consume(engine: Any, losses_reduced: Any) 
                             big_tensor = reordered
                     except Exception:
                         pass
+
+                # The ObjectRef is consumed by SpecoTaskRunner, which has no
+                # accelerator allocation.  CPU staging is intentional and
+                # matches the existing PP=1 per-sample ObjectRef transport.
+                big_tensor = _to_cpu_transfer_tensor(big_tensor)
 
                 whole_ref = None
                 try:

--- a/verl_speco/integration/oldlogprob_runtime.py
+++ b/verl_speco/integration/oldlogprob_runtime.py
@@ -238,7 +238,7 @@ def _selected_device(selected: Any):
 def _to_cpu_transfer_tensor(value: Any):
     """Detach tensors before sending SPECO side-channel data through Ray.
 
-    ``DataProto.non_tensor_batch`` is serialized by Ray as a Python payload.
+    ``non_tensor_batch`` is serialized by Ray as a Python payload.
     It must therefore never contain an accelerator-resident tensor: the
     receiving task runner deliberately owns no accelerator resources.  Drafter
     workers move collected features back to their local device before training.
@@ -2786,9 +2786,7 @@ def _megatron_post_stage_exchange_and_consume(engine: Any, losses_reduced: Any) 
                 )
                 # Timing follows the same non-tensor Ray side channel as
                 # hidden-state metadata after worker postprocessing.
-                model_output[OLD_LOGPROB_TIMING_KEY] = _to_cpu_transfer_tensor(
-                    timing
-                )
+                model_output[OLD_LOGPROB_TIMING_KEY] = _to_cpu_transfer_tensor(timing)
 
             # Concatenate all microbatches' hidden states into one big tensor,
             # then ray.put() ONCE.  Owner = this last-stage process, so the

--- a/verl_speco/integration/oldlogprob_runtime.py
+++ b/verl_speco/integration/oldlogprob_runtime.py
@@ -246,12 +246,24 @@ def _to_cpu_transfer_tensor(value: Any):
 
     try:
         import torch
+    except ImportError:
+        torch = None
 
-        if torch.is_tensor(value):
-            return value.detach().to(device="cpu", copy=True).contiguous()
-    except Exception:  # noqa: BLE001
-        pass
-    return value
+    def transfer(item: Any):
+        if torch is not None and torch.is_tensor(item):
+            item = item.detach()
+            if item.device.type == "cpu":
+                return item.contiguous()
+            return item.to(device="cpu", copy=True).contiguous()
+        if isinstance(item, dict):
+            return {key: transfer(child) for key, child in item.items()}
+        if isinstance(item, list):
+            return [transfer(child) for child in item]
+        if isinstance(item, tuple):
+            return tuple(transfer(child) for child in item)
+        return item
+
+    return transfer(value)
 
 
 def _row_indices_payload(row_indices: Any):

--- a/verl_speco/integration/rollout_publish.py
+++ b/verl_speco/integration/rollout_publish.py
@@ -225,6 +225,7 @@ def install_oldlogprob_hidden_runtime_for_worker(worker: Any) -> None:
     try:
         from verl_speco.integration.oldlogprob_runtime import (
             install_oldlogprob_hidden_runtime_patch,
+            install_oldlogprob_hidden_runtime_patch_megatron,
             oldlogprob_hidden_runtime_enabled,
         )
     except Exception:  # noqa: BLE001
@@ -240,6 +241,7 @@ def install_oldlogprob_hidden_runtime_for_worker(worker: Any) -> None:
     actor_backend = actor_training_backend_name(getattr(worker, "config", None))
     if actor_backend != "veomni":
         install_oldlogprob_hidden_runtime_patch()
+        install_oldlogprob_hidden_runtime_patch_megatron()
         return
 
     patched = install_oldlogprob_hidden_runtime_patch(actor_backend="veomni")

--- a/verl_speco/trainer/base_trainer.py
+++ b/verl_speco/trainer/base_trainer.py
@@ -28,6 +28,7 @@ from contextlib import contextmanager, nullcontext
 
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
 from torch.nn import SmoothL1Loss
@@ -1018,6 +1019,24 @@ class DrafterBaseTrainer:
         if fsdp_config is None:
             fsdp_config = self.config.rollout.drafter.training.get("fsdp_config")
         if fsdp_config is None:
+            # When the main model uses Megatron, the actor config has no
+            # fsdp_config (it uses megatron.* instead).  The drafter is
+            # always trained with FSDP, so provide a default config.
+            actor_strategy = ""
+            if hasattr(self.config, "actor"):
+                actor_strategy = str(
+                    getattr(self.config.actor, "strategy", "") or ""
+                ).lower()
+            if actor_strategy in {"megatron", "mindspeed_megatron"}:
+                from verl.workers.config import FSDPEngineConfig
+
+                fsdp_config = FSDPEngineConfig()
+                logger.warning(
+                    "SPECO drafter: actor strategy=%s has no fsdp_config; "
+                    "using default FSDPEngineConfig for drafter training",
+                    actor_strategy,
+                )
+        if fsdp_config is None:
             raise ValueError(
                 "FSDP config is missing: expect actor_rollout_ref.actor.fsdp_config or drafter override"
             )
@@ -1316,12 +1335,8 @@ class DrafterBaseTrainer:
 
     def _get_pretrained_export_model(self):
         model = self.model.module if hasattr(self.model, "module") else self.model
-        # Trainer wrappers (the DFlash family and P-EAGLE) keep the exportable
-        # draft as ``draft_model``; the checkpoint must hold the draft itself, so
-        # unwrap whenever a wrapper is present rather than per backend type.
-        draft_model = getattr(model, "draft_model", None)
-        if draft_model is not None:
-            return draft_model, (
+        if self._is_block_drafter_backend() and hasattr(model, "draft_model"):
+            return model.draft_model, (
                 "draft_model.",
                 "module.draft_model.",
                 "_orig_mod.draft_model.",
@@ -4507,16 +4522,33 @@ class DrafterBaseTrainer:
         self.record_training_timing(
             "timing_s/drafter_prepare_batch", time.time() - prepare_ts
         )
+        if batch is None:
+            logger.debug(
+                f"[DrafterTrainer rank {self.rank}] Not enough data at step {step} "
+                f"(have={len(self.collected_data)} need>={self.batch_size})"
+            )
+            try:
+                eval_metrics = self.evaluate_drafter_quality()
+                if eval_metrics:
+                    self._training_metric_sums.update(
+                        {f"eval_{k}": v for k, v in eval_metrics.items()}
+                    )
+                    logger.warning(
+                        "[drafter eval probe] step=%s top1=%.4f entropy=%.4f kl=%.4f tokens=%s",
+                        step,
+                        eval_metrics.get("drafter/eval_top1_match", 0.0),
+                        eval_metrics.get("drafter/eval_actor_entropy", 0.0),
+                        eval_metrics.get("drafter/eval_kl_actor_drafter", 0.0),
+                        eval_metrics.get("drafter/eval_token_count", 0),
+                    )
+            except Exception as exc:
+                logger.debug("[drafter eval probe] failed: %s", exc)
         if not self._sync_batch_readiness(batch is not None):
             logger.debug(
                 f"[DrafterTrainer rank {self.rank}] Skipping step {step} due to missing drafter batch"
             )
             return False
         if batch is None:
-            logger.debug(
-                f"[DrafterTrainer rank {self.rank}] Not enough data at step {step} "
-                f"(have={len(self.collected_data)} need>={self.batch_size})"
-            )
             return False
 
         return await self._training_step_on_batch(batch, step)
@@ -4659,6 +4691,223 @@ class DrafterBaseTrainer:
             float(ploss.item()),
         )
         return True
+
+    @torch.no_grad()
+    def evaluate_drafter_quality(self) -> dict[str, float]:
+        """Evaluate drafter prediction quality without training.
+
+        Directly compares actor vs drafter output distributions on collected
+        rollout data.  Runs even when prepare_training_batch returns None
+        (i.e. no_trainable_batch), so quality can be tracked every step.
+
+        Produces:
+          drafter/eval_top1_match      P(drafter_argmax == actor_argmax)
+          drafter/eval_top5_match      P(actor_argmax in drafter top-5)
+          drafter/eval_actor_entropy   mean Shannon entropy of actor dist
+          drafter/eval_drafter_entropy mean Shannon entropy of drafter dist
+          drafter/eval_kl_actor_drafter  KL(actor || drafter)
+          drafter/eval_exp_acceptance    expected spec-decode acceptance prob
+          drafter/eval_token_count     number of evaluated tokens
+        """
+        if not self.model or not self.collected_data:
+            return {}
+        items = list(self.collected_data)[: min(4, len(self.collected_data))]
+        items = [it for it in items if "hidden_states" in it]
+        if not items:
+            return {}
+
+        try:
+            dev = next(self.model.parameters()).device
+        except StopIteration:
+            return {}
+
+        use_logits = bool(self.config.rollout.drafter.training.get("use_logits", False))
+        try:
+            pre = self.backend.preprocess_individual_items(
+                items, dev, self.model_config
+            )
+        except Exception:
+            logger.debug(
+                "[drafter eval probe] preprocess failed for %s items", len(items)
+            )
+            return {}
+
+        ids_list = pre["ids"]
+        hidden_list = pre["h_states"]
+        mask_list = pre["masks"]
+        pos_list = pre.get("position_ids")
+        last_h_list = pre.get("last_h_states")
+        target_lp_list = pre.get("target_logprobs")
+
+        if not ids_list:
+            return {}
+
+        def _pad(tensors, dim=0, value=0):
+            tensors = [
+                t.squeeze(0) if t.dim() == 3 and t.size(0) == 1 else t for t in tensors
+            ]
+            max_len = max(t.size(dim) for t in tensors)
+            padded = []
+            for t in tensors:
+                pad_shape = list(t.shape)
+                pad_shape[dim] = max_len - t.size(dim)
+                if pad_shape[dim] > 0:
+                    pad_t = torch.zeros(pad_shape, dtype=t.dtype, device=t.device)
+                    pad_t.fill_(value)
+                    padded.append(torch.cat([t, pad_t], dim=dim))
+                else:
+                    padded.append(t)
+            return torch.stack(padded, dim=0)
+
+        bsz = len(ids_list)
+        input_ids = _pad(ids_list, dim=0, value=self.pad_token_id).unsqueeze(1)
+        hidden_states = _pad(hidden_list, dim=0).unsqueeze(1)
+        loss_mask = _pad(mask_list, dim=0, value=0.0).unsqueeze(1)
+        if pos_list is not None and pos_list[0] is not None:
+            position_ids = _pad(pos_list, dim=0, value=0).unsqueeze(1)
+        else:
+            max_len = input_ids.size(1)
+            position_ids = (
+                torch.arange(max_len, device=dev)
+                .unsqueeze(0)
+                .unsqueeze(0)
+                .expand(bsz, 1, max_len)
+            )
+
+        attn_mask = (input_ids != self.pad_token_id).long()
+        batch = {
+            "input_ids": input_ids,
+            "hidden_states": hidden_states,
+            "attention_mask": attn_mask,
+            "loss_mask": loss_mask,
+            "position_ids": position_ids,
+        }
+        if self.backend.model_type == "eagle3" and not use_logits:
+            if last_h_list is None or last_h_list[0] is None:
+                return {}
+            batch["last_hidden_states"] = _pad(last_h_list, dim=0).unsqueeze(1)
+        elif self.backend.model_type == "eagle3" and use_logits:
+            if target_lp_list is None or target_lp_list[0] is None:
+                return {}
+            batch["target_logprobs"] = _pad(target_lp_list, dim=0).unsqueeze(1)
+
+        draft_model = self.model
+        try:
+            with torch.amp.autocast(device_type=device_name, dtype=torch.bfloat16):
+                outputs = draft_model(
+                    input_ids=batch["input_ids"],
+                    hidden_states=batch["hidden_states"],
+                    attention_mask=batch["attention_mask"],
+                    loss_mask=batch["loss_mask"],
+                    position_ids=batch["position_ids"],
+                    ttt_length=1,
+                )
+            drafter_logits = outputs["logits"][0]
+        except Exception:
+            logger.debug("[drafter eval probe] drafter forward failed")
+            return {}
+
+        if use_logits:
+            target_topk = batch["target_logprobs"]
+            from verl_speco.backends.eagle3_trainer_backend import (
+                _target_topk_to_draft_ids,
+            )
+
+            t2d = draft_model.t2d.to(device=dev, dtype=torch.bool)
+            token_ids = target_topk[..., 1].long()
+            valid = torch.isfinite(target_topk[..., 0])
+            draft_ids, in_draft = _target_topk_to_draft_ids(token_ids, valid, t2d)
+            actor_top1 = draft_ids[..., 0]
+            actor_logprobs_vals = target_topk[..., 0]
+        else:
+            last_hidden = batch["last_hidden_states"]
+            with torch.amp.autocast(device_type=device_name, dtype=torch.bfloat16):
+                target_scores = self.backend.target_model(last_hidden)
+            t2d = draft_model.t2d.to(device=dev, dtype=torch.bool)
+            if target_scores.size(-1) == t2d.numel():
+                target_subset = target_scores[..., t2d]
+            else:
+                target_subset = target_scores
+            actor_logprobs_full = F.log_softmax(target_subset.float(), dim=-1)
+            actor_top1 = actor_logprobs_full.argmax(dim=-1)
+            actor_logprobs_vals = actor_logprobs_full.gather(
+                -1, actor_top1.unsqueeze(-1)
+            ).squeeze(-1)
+
+        drafter_step_logits = drafter_logits[0]
+        drafter_logprobs = F.log_softmax(drafter_step_logits.float(), dim=-1)
+        drafter_top1 = drafter_logprobs.argmax(dim=-1)
+
+        pos_mask = batch["loss_mask"][0].squeeze(-1)
+        if pos_mask.dim() > 1:
+            pos_mask = pos_mask.squeeze(-1)
+        seq_len = min(
+            drafter_top1.size(0),
+            actor_top1.size(0),
+            pos_mask.size(0),
+        )
+        pos_mask = pos_mask[:seq_len].bool()
+        if not pos_mask.any():
+            return {}
+
+        drafter_top1 = drafter_top1[:seq_len]
+        actor_top1 = actor_top1[:seq_len]
+        drafter_lp = drafter_logprobs[:seq_len]
+        if use_logits:
+            actor_lp = actor_logprobs_vals[:seq_len]
+        else:
+            actor_lp_full = actor_logprobs_full[:seq_len]
+            actor_lp = actor_lp_full.gather(-1, actor_top1.unsqueeze(-1)).squeeze(-1)
+
+        top1_match = (drafter_top1 == actor_top1).float()
+        top1_match = top1_match[pos_mask]
+
+        drafter_topk = drafter_logprobs[:seq_len].topk(5, dim=-1).indices
+        top5_match = (drafter_topk == actor_top1.unsqueeze(-1)).any(dim=-1).float()
+        top5_match = top5_match[pos_mask]
+
+        drafter_probs = drafter_lp.exp()
+        drafter_entropy = -(drafter_probs * drafter_lp).sum(dim=-1)
+        if use_logits:
+            actor_probs = actor_lp.exp()
+            actor_entropy = -(actor_probs * actor_lp)
+        else:
+            actor_entropy = -(actor_lp_full.exp() * actor_lp_full).sum(dim=-1)
+        actor_entropy = actor_entropy[:seq_len]
+
+        if use_logits:
+            min_v = min(drafter_lp.size(-1), actor_lp.size(-1))
+        else:
+            min_v = min(drafter_lp.size(-1), actor_lp_full.size(-1))
+        d_p = drafter_probs[:seq_len, :min_v] + 1e-12
+        if use_logits:
+            a_p = actor_probs[:seq_len, :min_v] + 1e-12
+        else:
+            a_p = actor_lp_full[:seq_len, :min_v].exp() + 1e-12
+        kl_ad = (a_p * (a_p.log() - d_p.log())).sum(dim=-1)
+        kl_ad = kl_ad[pos_mask]
+
+        log_ratio = drafter_lp[:seq_len, :min_v] - (
+            actor_lp[:seq_len, :min_v]
+            if use_logits
+            else actor_lp_full[:seq_len, :min_v]
+        )
+        exp_acc = (a_p * torch.exp(log_ratio).clamp(max=1.0)).sum(dim=-1)
+        exp_acc = exp_acc[pos_mask]
+
+        token_count = pos_mask.float().sum().item()
+        if token_count <= 0:
+            return {}
+
+        return {
+            "drafter/eval_top1_match": top1_match.mean().item(),
+            "drafter/eval_top5_match": top5_match.mean().item(),
+            "drafter/eval_actor_entropy": actor_entropy[pos_mask].mean().item(),
+            "drafter/eval_drafter_entropy": drafter_entropy[pos_mask].mean().item(),
+            "drafter/eval_kl_actor_drafter": kl_ad.mean().item(),
+            "drafter/eval_exp_acceptance": exp_acc.mean().item(),
+            "drafter/eval_token_count": token_count,
+        }
 
     def increment_rl_step(self, global_step: Optional[int] = None):
         """Increment the RL step counter in the data buffer.

--- a/verl_speco/trainer/speco_ray_trainer.py
+++ b/verl_speco/trainer/speco_ray_trainer.py
@@ -31,32 +31,34 @@ from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 from verl.trainer.ppo.utils import Role
 from verl.utils import tensordict_utils as tu
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
+
 from verl_speco.integration.agent_loop_runtime import (
     SPECO_AGENT_LOOP_MANAGER_CLASS,
     install_agent_loop_runtime_patch,
 )
-from verl_speco.integration.rollout_publish import resolve_drafter_publish_payload
+from verl_speco.integration.oldlogprob_layer_ids import (
+    assert_sglang_aux_last_layer_norm_safe,
+    resolve_oldlogprob_aux_layer_ids,
+)
 from verl_speco.integration.oldlogprob_runtime import (
     OLD_LOGPROB_AUX_LAYER_IDS_KEY,
     OLD_LOGPROB_COLLECT_MASK_KEY,
     OLD_LOGPROB_HIDDEN_CAPTURE_IMPL_KEY,
     OLD_LOGPROB_HIDDEN_CHUNK_META_KEY,
     OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY,
-    OLD_LOGPROB_HIDDEN_OBJECT_REF_KEY,
     OLD_LOGPROB_HIDDEN_LAYOUT_KEY,
+    OLD_LOGPROB_HIDDEN_OBJECT_REF_KEY,
     OLD_LOGPROB_HIDDEN_POSITION_MASK_KEY,
     OLD_LOGPROB_HIDDEN_POSITIONS_KEY,
     OLD_LOGPROB_HIDDEN_REF_META_KEY,
     OLD_LOGPROB_HIDDEN_REFS_KEY,
     OLD_LOGPROB_HIDDEN_STATES_KEY,
+    OLD_LOGPROB_HIDDEN_WHOLE_REF_KEY,
+    OLD_LOGPROB_HIDDEN_WHOLE_REF_META_KEY,
     OLD_LOGPROB_OWNER_RANK_KEY,
     OLD_LOGPROB_TIMING_KEY,
 )
-from verl_speco.integration.oldlogprob_layer_ids import (
-    assert_sglang_aux_last_layer_norm_safe,
-    resolve_drafter_hidden_states_layout,
-    resolve_oldlogprob_aux_layer_ids,
-)
+from verl_speco.integration.rollout_publish import resolve_drafter_publish_payload
 from verl_speco.integration.sglang_adapter import (
     bucket_drafter_samples_by_replica,
     pop_drafter_samples,
@@ -72,9 +74,7 @@ from verl_speco.integration.vllm_runtime import (
     SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX,
     configure_vllm_runtime_from_config,
 )
-from verl_speco.trainer.bubble_profiler import inject_bubble_metrics
 from verl_speco.workers import SpecoWorker
-
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -889,11 +889,44 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             _get_nested(self.config, ("actor_rollout_ref", "actor", "strategy"), "")
             or ""
         ).lower()
-        if strategy not in {"fsdp", "fsdp2", "veomni"}:
+        if strategy not in {"fsdp", "fsdp2", "megatron", "veomni"}:
             raise ValueError(
                 "SPECO old-logprob hidden collection supports "
-                "actor.strategy=fsdp/fsdp2/veomni, "
+                "actor.strategy=fsdp/fsdp2/megatron/veomni, "
                 f"got {strategy!r}"
+            )
+        if strategy == "megatron":
+            tp_size = int(
+                _get_nested(
+                    self.config,
+                    (
+                        "actor_rollout_ref",
+                        "actor",
+                        "megatron",
+                        "tensor_model_parallel_size",
+                    ),
+                    1,
+                )
+                or 1
+            )
+            pp_size = int(
+                _get_nested(
+                    self.config,
+                    (
+                        "actor_rollout_ref",
+                        "actor",
+                        "megatron",
+                        "pipeline_model_parallel_size",
+                    ),
+                    1,
+                )
+                or 1
+            )
+            logger.warning(
+                "SPECO old-logprob hidden collection with Megatron backend: "
+                f"TP={tp_size}, PP={pp_size}. "
+                "TP>1 uses Megatron native sequence parallelism for hidden-state gathering. "
+                "PP>1 uses cross-stage dist communication for capture transfer."
             )
         capture_impl = str(
             training_cfg.get("old_logprob_hidden_capture_impl", "forward_hook")
@@ -902,6 +935,11 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         if capture_impl not in {"forward_hook", "output_hidden_states"}:
             raise ValueError(
                 f"Unsupported SPECO old-logprob hidden capture impl: {capture_impl!r}"
+            )
+        if strategy == "megatron" and capture_impl != "forward_hook":
+            raise ValueError(
+                "SPECO old-logprob hidden collection with Megatron backend supports "
+                f"forward_hook capture only, got {capture_impl!r}"
             )
         return True
 
@@ -941,9 +979,19 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
 
     def _speco_oldlogprob_hidden_layout(self) -> str:
         drafter_cfg = self._speco_drafter_config()
-        algorithm = _get_nested(drafter_cfg, ("speculative_algorithm",), "")
-        return resolve_drafter_hidden_states_layout(
-            algorithm, self._speco_drafter_training_config()
+        algorithm = str(
+            _get_nested(drafter_cfg, ("speculative_algorithm",), "") or ""
+        ).upper()
+        training_cfg = self._speco_drafter_training_config()
+        if (
+            algorithm == "DSPARK"
+            and float(training_cfg.get("dspark_l1_loss_alpha", 0.9) or 0.0) > 0
+        ):
+            return "dflash_aux_plus_last"
+        return (
+            "dflash_aux"
+            if algorithm in {"DFLASH", "DSPARK"}
+            else "eagle3_aux_plus_last"
         )
 
     @staticmethod
@@ -1314,6 +1362,30 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         chunk_meta = self._speco_flatten_non_tensor_rows(
             tu.get(output, OLD_LOGPROB_HIDDEN_CHUNK_META_KEY)
         )
+        # PP>1 single-put path: the last stage ray.put()s the concatenated
+        # hidden tensor once and returns the ObjectRef.  Materialize it here
+        # (once) and release the ref immediately so the big tensor does not pin
+        # the Ray object store; the rest of this function treats it as an
+        # inline tensor.
+        whole_ref = tu.get(output, OLD_LOGPROB_HIDDEN_WHOLE_REF_KEY)
+        if hidden_states is None and whole_ref is not None:
+            import ray as _ray
+
+            hidden_states = _ray.get(whole_ref)
+            # Drop every reference to the ObjectRef (local var + the copy held
+            # inside the output TensorDict) so Ray can free the big tensor from
+            # the object store as soon as this materialization completes,
+            # instead of waiting for the whole step output to be GC'd.
+            del whole_ref
+            try:
+                tu.assign_non_tensor_data(
+                    output, OLD_LOGPROB_HIDDEN_WHOLE_REF_KEY, None
+                )
+                tu.assign_non_tensor_data(
+                    output, OLD_LOGPROB_HIDDEN_WHOLE_REF_META_KEY, None
+                )
+            except Exception:
+                pass
         if hidden_states is None and hidden_refs is None and chunk_refs is None:
             return 0
         hidden_rows = self._speco_tensor_rows(hidden_states)
@@ -2075,30 +2147,6 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         finally:
             rollout_generation_target.generate_sequences = original_generate_sequences
 
-    def _speco_bubble_profiler_enabled(self) -> bool:
-        return bool(
-            _get_nested(
-                self.config,
-                ("actor_rollout_ref", "rollout", "drafter", "profile_bubble"),
-                False,
-            )
-        )
-
-    def _speco_augment_log_data(
-        self, data: Any, latest_rollout_metrics: dict[str, float]
-    ) -> Any:
-        if (
-            isinstance(data, dict)
-            and isinstance(latest_rollout_metrics, dict)
-            and data.get("training/global_step") == self.global_steps
-        ):
-            data = dict(data)
-            data.update(latest_rollout_metrics)
-        data = _speco_move_drafter_timing_next_to_update_actor(data)
-        if self._speco_bubble_profiler_enabled():
-            data = inject_bubble_metrics(data)
-        return data
-
     @contextmanager
     def _speco_tracking_metrics_hook(self):
         try:
@@ -2118,13 +2166,27 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             latest_rollout_metrics = self._speco_current_step_rollout_metrics()
             if "data" in kwargs:
                 kwargs = dict(kwargs)
-                kwargs["data"] = self._speco_augment_log_data(
-                    kwargs["data"], latest_rollout_metrics
-                )
+                data = kwargs["data"]
+                if (
+                    isinstance(data, dict)
+                    and isinstance(latest_rollout_metrics, dict)
+                    and data.get("training/global_step") == self.global_steps
+                ):
+                    data = dict(data)
+                    data.update(latest_rollout_metrics)
+                kwargs["data"] = _speco_move_drafter_timing_next_to_update_actor(data)
                 return original_log(tracking_self, *args, **kwargs)
             if args:
+                data = args[0]
+                if (
+                    isinstance(data, dict)
+                    and isinstance(latest_rollout_metrics, dict)
+                    and data.get("training/global_step") == self.global_steps
+                ):
+                    data = dict(data)
+                    data.update(latest_rollout_metrics)
                 args = (
-                    self._speco_augment_log_data(args[0], latest_rollout_metrics),
+                    _speco_move_drafter_timing_next_to_update_actor(data),
                     *args[1:],
                 )
             return original_log(tracking_self, *args, **kwargs)
@@ -2313,6 +2375,18 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
                 self._speco_oldlogprob_hidden_layout(),
             )
             tu.assign_non_tensor_data(batch_td, OLD_LOGPROB_HIDDEN_OBJECT_REF_KEY, True)
+            # Pass the user's sequence_parallel setting through the batch,
+            # because MindSpeed repatch may override tf_config.sequence_parallel
+            # back to True even when the user sets it to False.
+            _actor_megatron_cfg = _get_nested(
+                self.config, ("actor_rollout_ref", "actor", "megatron"), {}
+            )
+            _user_seq_parallel = _actor_megatron_cfg.get("sequence_parallel", True)
+            tu.assign_non_tensor_data(
+                batch_td,
+                "speco_oldlogprob_sp_disabled",
+                not bool(_user_seq_parallel),
+            )
 
             self._speco_last_oldlogprob_prepare_elapsed_sec = (
                 time.perf_counter() - prepare_started
@@ -2450,14 +2524,12 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             generate_sequences_with_speco,
             rollout_generation_target,
         )
-        if self._speco_oldlogprob_collection_requested():
+        if (
+            self._speco_oldlogprob_collection_requested()
+            or self._speco_oldlogprob_entropy_hook_enabled()
+        ):
             self._compute_old_log_prob = MethodType(
                 compute_old_log_prob_with_speco, self
-            )
-        elif self._speco_oldlogprob_entropy_hook_enabled():
-            self._compute_old_log_prob = MethodType(
-                compute_old_log_prob_with_speco,
-                self,
             )
         self._update_actor = MethodType(update_actor_with_speco, self)
         if defer_publish_until_update_weights:

--- a/verl_speco/trainer/speco_ray_trainer.py
+++ b/verl_speco/trainer/speco_ray_trainer.py
@@ -31,23 +31,19 @@ from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 from verl.trainer.ppo.utils import Role
 from verl.utils import tensordict_utils as tu
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
-
 from verl_speco.integration.agent_loop_runtime import (
     SPECO_AGENT_LOOP_MANAGER_CLASS,
     install_agent_loop_runtime_patch,
 )
-from verl_speco.integration.oldlogprob_layer_ids import (
-    assert_sglang_aux_last_layer_norm_safe,
-    resolve_oldlogprob_aux_layer_ids,
-)
+from verl_speco.integration.rollout_publish import resolve_drafter_publish_payload
 from verl_speco.integration.oldlogprob_runtime import (
     OLD_LOGPROB_AUX_LAYER_IDS_KEY,
     OLD_LOGPROB_COLLECT_MASK_KEY,
     OLD_LOGPROB_HIDDEN_CAPTURE_IMPL_KEY,
     OLD_LOGPROB_HIDDEN_CHUNK_META_KEY,
     OLD_LOGPROB_HIDDEN_CHUNK_REFS_KEY,
-    OLD_LOGPROB_HIDDEN_LAYOUT_KEY,
     OLD_LOGPROB_HIDDEN_OBJECT_REF_KEY,
+    OLD_LOGPROB_HIDDEN_LAYOUT_KEY,
     OLD_LOGPROB_HIDDEN_POSITION_MASK_KEY,
     OLD_LOGPROB_HIDDEN_POSITIONS_KEY,
     OLD_LOGPROB_HIDDEN_REF_META_KEY,
@@ -58,7 +54,11 @@ from verl_speco.integration.oldlogprob_runtime import (
     OLD_LOGPROB_OWNER_RANK_KEY,
     OLD_LOGPROB_TIMING_KEY,
 )
-from verl_speco.integration.rollout_publish import resolve_drafter_publish_payload
+from verl_speco.integration.oldlogprob_layer_ids import (
+    assert_sglang_aux_last_layer_norm_safe,
+    resolve_drafter_hidden_states_layout,
+    resolve_oldlogprob_aux_layer_ids,
+)
 from verl_speco.integration.sglang_adapter import (
     bucket_drafter_samples_by_replica,
     pop_drafter_samples,
@@ -74,7 +74,9 @@ from verl_speco.integration.vllm_runtime import (
     SPECO_VLLM_SPEC_DECODE_EXTRA_PREFIX,
     configure_vllm_runtime_from_config,
 )
+from verl_speco.trainer.bubble_profiler import inject_bubble_metrics
 from verl_speco.workers import SpecoWorker
+
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -979,19 +981,9 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
 
     def _speco_oldlogprob_hidden_layout(self) -> str:
         drafter_cfg = self._speco_drafter_config()
-        algorithm = str(
-            _get_nested(drafter_cfg, ("speculative_algorithm",), "") or ""
-        ).upper()
-        training_cfg = self._speco_drafter_training_config()
-        if (
-            algorithm == "DSPARK"
-            and float(training_cfg.get("dspark_l1_loss_alpha", 0.9) or 0.0) > 0
-        ):
-            return "dflash_aux_plus_last"
-        return (
-            "dflash_aux"
-            if algorithm in {"DFLASH", "DSPARK"}
-            else "eagle3_aux_plus_last"
+        algorithm = _get_nested(drafter_cfg, ("speculative_algorithm",), "")
+        return resolve_drafter_hidden_states_layout(
+            algorithm, self._speco_drafter_training_config()
         )
 
     @staticmethod
@@ -2147,6 +2139,30 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
         finally:
             rollout_generation_target.generate_sequences = original_generate_sequences
 
+    def _speco_bubble_profiler_enabled(self) -> bool:
+        return bool(
+            _get_nested(
+                self.config,
+                ("actor_rollout_ref", "rollout", "drafter", "profile_bubble"),
+                False,
+            )
+        )
+
+    def _speco_augment_log_data(
+        self, data: Any, latest_rollout_metrics: dict[str, float]
+    ) -> Any:
+        if (
+            isinstance(data, dict)
+            and isinstance(latest_rollout_metrics, dict)
+            and data.get("training/global_step") == self.global_steps
+        ):
+            data = dict(data)
+            data.update(latest_rollout_metrics)
+        data = _speco_move_drafter_timing_next_to_update_actor(data)
+        if self._speco_bubble_profiler_enabled():
+            data = inject_bubble_metrics(data)
+        return data
+
     @contextmanager
     def _speco_tracking_metrics_hook(self):
         try:
@@ -2166,27 +2182,13 @@ class SpecoRayPPOTrainer(RayPPOTrainer):
             latest_rollout_metrics = self._speco_current_step_rollout_metrics()
             if "data" in kwargs:
                 kwargs = dict(kwargs)
-                data = kwargs["data"]
-                if (
-                    isinstance(data, dict)
-                    and isinstance(latest_rollout_metrics, dict)
-                    and data.get("training/global_step") == self.global_steps
-                ):
-                    data = dict(data)
-                    data.update(latest_rollout_metrics)
-                kwargs["data"] = _speco_move_drafter_timing_next_to_update_actor(data)
+                kwargs["data"] = self._speco_augment_log_data(
+                    kwargs["data"], latest_rollout_metrics
+                )
                 return original_log(tracking_self, *args, **kwargs)
             if args:
-                data = args[0]
-                if (
-                    isinstance(data, dict)
-                    and isinstance(latest_rollout_metrics, dict)
-                    and data.get("training/global_step") == self.global_steps
-                ):
-                    data = dict(data)
-                    data.update(latest_rollout_metrics)
                 args = (
-                    _speco_move_drafter_timing_next_to_update_actor(data),
+                    self._speco_augment_log_data(args[0], latest_rollout_metrics),
                     *args[1:],
                 )
             return original_log(tracking_self, *args, **kwargs)


### PR DESCRIPTION
## Basic information

**Scope:** Add Pipeline Parallelism (PP>1) and Sequence Parallelism (SP=True) support to the Megatron old-logprob hidden-state collection path, enabling EAGLE3 drafter co-training under TP+SP+PP topologies (e.g. Qwen3-4B TP4PP2, Qwen3-8B TP8PP1) on NPU.

**Background:** verl-SpeCo's EAGLE3 drafter online training captures specific-layer hidden states (aux layers + final-norm output) from the target model's `compute_old_log_prob` forward via `register_forward_hook`, then selects/merges/distributes them to drafter training workers. The previously merged `efad0aa` only supports Megatron **TP**; this PR adds PP>1 cross-stage exchange and fixes SP=True under PP async actors.

**Problem solved:** When PP>1, aux layers are split across pipeline stages — each stage's forward hook can only capture its local layers, so captures must be exchanged across stages and merged at the last stage. SP=True additionally shards hidden states across TP ranks, requiring all TP ranks to participate in the exchange.

### Key changes

1. **Temp-file cross-stage exchange** (`oldlogprob_runtime.py`). Non-last stages pickle captures to `/dev/shm/speco_pp_exchange/pp_{rank}_fbb_tp{N}.pkl` (atomic `.tmp`+`rename`); the last stage polls (30s timeout), loads, and merges. This avoids HCCL P2P (deadlocks on NPU `isend/irecv`) and Ray object-store blocking (which freezes the async-actor event loop and deadlocks pipeline HCCL collectives).
2. **Single `ray.put` of the final concatenated tensor** at the last stage (owner is correct), instead of 132 per-microbatch `ray.put`s that would pin object store → spill → disk pressure. Task runner `ray.get`s once and immediately `del`s the ref.
3. **`index_copy_` reorder** from micro-batch to full-batch order using `indices` saved by `speco_aggregate_output` — fixes the sample-misalignment regression where `use_dynamic_bsz=True` caused acceptance to drop (2.03→1.98).
4. **SP=True hardening** (`c8fdc53`): per-`tp_rank` file tag (`fbb_tp{N}`) so every TP rank exchanges its distinct SP shard; sparse-aware device inference + CPU→device remap after pickle round-trip; dense conversion; `tp_rank=0`-only attach guard; expected-warning downgrade to debug.
5. **Context cleanup** after exchange so the subsequent ref log_prob (no collect mask) does not enter exchange and write an empty temp file — fixes `no_trainable_batch` on step 2+.
6. **Bug fixes** (§2.5): wrong `load_format` key (acceptance=1.0), `nbytes()` TypeError, empty-file skip, context clear.

### Design notes

- **PP>1/PP=1 isolation:** three branch points (`speco_megatron_postprocess`, `_megatron_post_stage_exchange_and_consume`, `_megatron_save_stage_captures`) fully isolate the two paths; PP=1 is byte-for-byte identical to `efad0aa` and unaffected.
- **Upstream zero-modification:** all TP/SP/PP logic lives in `verl_speco/` via monkey-patch; Megatron-LM / MindSpeed / vllm-ascend / verl upstream core source is untouched.
- **NPU/GPU not hard-bound:** `oldlogprob_runtime.py` has 0 NPU code lines — device is inferred from saved-capture tensors; `speco_mem_watchdog.py` is 100% platform-agnostic (`/proc/meminfo` + `disk_usage` + OS signal).

## Test environment

| Item | Value |
|---|---|
| Hardware | Ascend NPU, 8 cards per node |
| Accelerators | `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7` (8 NPUs) |
| Actor backend | Megatron (TP=4, PP=2, SP=True) |
| Rollout | vLLM TP=2, enforce_eager=True, gpu_memory_utilization=0.5 |
| Model | Qwen3-4B (`Qwen/Qwen3-4B`) |
| Drafter | Qwen3-4B EAGLE3 (`AngelSlim/Qwen3-4B_eagle3_AngelSlim`) |
| Dataset | DAPO-Math-17k (train 10k / val) |
| Algorithm | GRPO, `use_kl_in_reward=False`, `kl_loss_coef=0.001` (low_var_kl) |
| Train batch | 64; ppo_mini_batch=16; ppo_micro_batch_per_gpu=10; dynamic_bsz=True |
| Drafter training | EAGLE3, spec_steps=3, spec_topk=1, spec_verify_tokens=4, step=20, collect/train_interval=1, publish_async=True, publish_dtype=bf16 |
| Ray | object_store_memory=200GB hard cap, temp_dir=/dev/shm/ray, spill_threshold=0.9, num_cpus=64, worker_soft_limit=8 |
| Watchdog | min_free_gb=250 (RAM), fs_min_free_gb=50 (/dev/shm + /), poll=10s |
| Max prompt / response | 512 / 8192 |
| Save/test freq | 10 / 5; total_epochs=1 |


## Test results

### A. Qwen3-4B TP4PP2 SP=True — primary run

Drafter acceptance length (every 5 steps):

| step | acceptance | step | acceptance |
|---|---|---|---|
| 1 | 2.031 | 50 | 2.310 |
| 5 | 2.206 | 65 | 2.305 |
| 10 | 2.236 | 80 | 2.269 |
| 15 | 2.273 | 95 | 2.275 |
| 30 | 2.323 | 100 | 2.278 |
| 45 (peak) | **2.355** | 102 (last) | 2.277 |

Stats: min=2.031, max=2.355, mean=2.284. Acceptance rose +12% in the first 15 steps, peaked at step 45, then stabilized around 2.28.

Validation accuracy (`val-core/math_dapo/acc/mean`, every 5 steps):

| step | val acc | step | val acc |
|---|---|---|---|
| 5 | 0.125 | 55 | 0.469 |
| 10 | 0.289 | 65 | 0.523 |
| 15 | 0.336 | 75 | 0.484 |
| 25 | 0.375 | 85 | **0.563** |
| 35 | 0.461 | 95 | 0.547 |
| 45 | 0.461 | 100 | 0.523 |

Val accuracy rose from 0.125 → ~0.52–0.56 (4× improvement).

Reward (`critic/score/mean`): −0.762 (step 1) → +0.050 (step 10) → oscillates near 0 as training progresses.

Step-5 timing breakdown (SP=True vs SP=False, seconds):

| phase | SP=False | SP=True |
|---|---|---|
| gen | 335 | 286 |
| old_log_prob | 265 | 276 |
| ref | 38 | 37 |
| update_actor | 94 | 88 |
| drafter | 12 | 17 |
| **step total** | **750** | **709** |

SP=True old_log_prob slightly higher (+11s, SP all-reduce) but step total slightly lower (−41s) — equivalent.

### B. SP=True vs SP=False equivalence (step 10)

| metric | SP=False | SP=True |
|---|---|---|
| acceptance | 2.235 | 2.236 |
| reward | +0.044 | +0.050 |

Equivalent — confirms the SP all-reduce deadlock is resolved; SP no longer needs to be disabled.

### C. FSDP2 vs Megatron-TP8PP1 equivalence (Qwen3-8B, step 1-10)

| step | FSDP2 acc | Megatron acc | FSDP2 reward | Megatron reward |
|---|---|---|---|---|
| 1 | 2.034 | 2.034 | −0.706 | −0.644 |
| 5 | 2.310 | 2.309 | −0.369 | −0.400 |
| 10 | 2.328 | 2.337 | +0.125 | +0.150 |

Per-step acceptance and reward curves overlap to within <0.01 — verifies Megatron-TP drafter training is equivalent to FSDP2.

### D. Stability

| | FSDP2 8B | Megatron 8B (TP8PP1) | Megatron 4B (TP4PP2) |
|---|---|---|---|
| steps run | 10 | 86 (first 10 compared) | 102 |
| trained=1.0 steps | 10/10 | 10/10 | 102/102 |
| crash/OOM | none | none | none |
| no_trainable_batch | none | none | none |