### PR TITLE
fix(dspark): re-apply verifier final RMSNorm in L1 distillation target

### DIFF
--- a/tests/integration/test_dspark_trainer_backend.py
+++ b/tests/integration/test_dspark_trainer_backend.py
@@ -404,3 +404,108 @@ def test_dspark_l1_reuses_only_full_vocab_ce_log_probs(
         for parameter in model.parameters()
         if parameter.requires_grad
     )
+
+
+def _manual_l1(
+    draft_log_probs: torch.Tensor,
+    target_hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    weights: torch.Tensor,
+    norm_weight: torch.Tensor | None,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    hidden = target_hidden.float()
+    if norm_weight is not None:
+        hidden = hidden * torch.rsqrt(hidden.pow(2).mean(dim=-1, keepdim=True) + eps)
+        hidden = hidden * norm_weight.float()
+    target_probs = torch.softmax(
+        (hidden.to(lm_head_weight.dtype) @ lm_head_weight.T).float(), dim=-1
+    )
+    draft_probs = draft_log_probs.exp()
+    return (draft_probs - target_probs).abs().sum(dim=-1).mul(weights).sum()
+
+
+def test_dspark_l1_target_applies_verifier_final_norm():
+    model = _small_dspark_training_model(block_size=2, l1_loss_alpha=1.0)
+    torch.manual_seed(0)
+    active_hidden = torch.randn(6, 8)
+    active_prev_tokens = torch.zeros(6, dtype=torch.long)
+    active_target_hidden = torch.randn(6, 8)
+    active_weights = torch.rand(6) + 0.5
+    lm_head_weight = torch.randn(32, 8)
+    norm_weight = torch.randn(8)
+    draft_log_probs = torch.log_softmax(torch.randn(6, 32), dim=-1)
+
+    l1_sum, l1_den = model._compute_l1_loss_for_active(
+        active_hidden=active_hidden,
+        active_prev_tokens=active_prev_tokens,
+        active_target_hidden=active_target_hidden,
+        active_weights=active_weights,
+        lm_head_weight=lm_head_weight,
+        active_draft_log_probs=draft_log_probs,
+        target_norm_weight=norm_weight,
+        target_norm_eps=1e-6,
+    )
+
+    expected = _manual_l1(
+        draft_log_probs,
+        active_target_hidden,
+        lm_head_weight,
+        active_weights,
+        norm_weight,
+    )
+    assert l1_den.item() == pytest.approx(active_weights.sum().item())
+    assert l1_sum.item() == pytest.approx(expected.item(), rel=1e-4, abs=1e-5)
+
+    plain_sum, _ = model._compute_l1_loss_for_active(
+        active_hidden=active_hidden,
+        active_prev_tokens=active_prev_tokens,
+        active_target_hidden=active_target_hidden,
+        active_weights=active_weights,
+        lm_head_weight=lm_head_weight,
+        active_draft_log_probs=draft_log_probs,
+        target_norm_weight=None,
+    )
+    plain_expected = _manual_l1(
+        draft_log_probs,
+        active_target_hidden,
+        lm_head_weight,
+        active_weights,
+        norm_weight=None,
+    )
+    assert plain_sum.item() == pytest.approx(
+        plain_expected.item(), rel=1e-4, abs=1e-5
+    )
+    # The norm must actually change the distillation target.
+    assert l1_sum.item() != pytest.approx(plain_sum.item(), rel=1e-3)
+
+
+def test_dspark_l1_norm_flows_through_forward(monkeypatch):
+    model = _small_dspark_training_model(block_size=2, l1_loss_alpha=0.5)
+    captured_norm = []
+    original_compute_l1 = model._compute_l1_loss_for_active
+
+    def capture_compute_l1(**kwargs):
+        captured_norm.append(kwargs.get("target_norm_weight"))
+        return original_compute_l1(**kwargs)
+
+    monkeypatch.setattr(model, "_compute_l1_loss_for_active", capture_compute_l1)
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.long)
+    loss_mask = torch.ones_like(input_ids, dtype=torch.float32)
+    hidden_states = [torch.randn(1, 5, 8), torch.randn(1, 5, 8)]
+    target_last_hidden_states = torch.randn(1, 5, 8)
+    lm_head_weight = torch.randn(32, 8)
+    norm_weight = torch.randn(8)
+
+    model(
+        input_ids=input_ids,
+        hidden_states_list=hidden_states,
+        loss_mask=loss_mask,
+        lm_head_weight=lm_head_weight,
+        target_last_hidden_states=target_last_hidden_states,
+        target_norm_weight=norm_weight,
+        target_norm_eps=1e-5,
+    )
+
+    assert len(captured_norm) == 1
+    assert captured_norm[0] is norm_weight

--- a/tests/integration/test_target_final_norm.py
+++ b/tests/integration/test_target_final_norm.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+
+import pytest
+
+torch = pytest.importorskip("torch")
+safetensors_torch = pytest.importorskip("safetensors.torch")
+
+target_head = pytest.importorskip("verl_speco.models.target.target_head")
+
+TargetFinalNorm = target_head.TargetFinalNorm
+
+
+@pytest.mark.parametrize(
+    ("model_type", "norm_key", "text_config", "expect_fold"),
+    [
+        ("qwen3", "model.norm.weight", False, False),
+        ("qwen3_5_text", "model.language_model.norm.weight", False, True),
+        ("qwen3_5", "model.norm.weight", True, True),
+        ("gemma3", "model.norm.weight", False, True),
+    ],
+)
+def test_target_final_norm_from_pretrained_folding(
+    tmp_path, model_type, norm_key, text_config, expect_fold
+):
+    eps = 5e-6
+    config = {
+        "model_type": model_type,
+        "rms_norm_eps": eps,
+        "hidden_size": 8,
+    }
+    if text_config:
+        config = {"model_type": f"{model_type}_vl", "text_config": dict(config)}
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    raw_norm = torch.randn(8)
+    safetensors_torch.save_file(
+        {norm_key: raw_norm, "lm_head.weight": torch.randn(32, 8)},
+        str(tmp_path / "model.safetensors"),
+    )
+
+    final_norm = TargetFinalNorm.from_pretrained(str(tmp_path))
+
+    assert final_norm.eps == pytest.approx(eps)
+    expected_weight = raw_norm + 1.0 if expect_fold else raw_norm
+    assert torch.allclose(final_norm.weight, expected_weight.float())
+    assert not final_norm.weight.requires_grad
+
+
+def test_target_final_norm_missing_weight_raises(tmp_path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen3", "rms_norm_eps": 1e-6})
+    )
+    safetensors_torch.save_file(
+        {"lm_head.weight": torch.randn(32, 8)},
+        str(tmp_path / "model.safetensors"),
+    )
+    with pytest.raises(KeyError, match="final-norm"):
+        TargetFinalNorm.from_pretrained(str(tmp_path))

--- a/verl_speco/backends/dspark_trainer_backend.py
+++ b/verl_speco/backends/dspark_trainer_backend.py
@@ -31,6 +31,7 @@ from verl_speco.backends.dflash_trainer_backend import (
 from verl_speco.models.dflash import resolve_rope_theta
 from verl_speco.models.dflash.flex_attention import compile_friendly_create_block_mask
 from verl_speco.models.dspark import DSparkConfig, DSparkDraftModel
+from verl_speco.models.target.target_head import TargetFinalNorm
 from verl_speco.trainer.checkpoint import log_drafter_checkpoint_step
 
 
@@ -259,6 +260,8 @@ class DSparkTrainingModel(DFlashTrainingModel):
         active_weights: torch.Tensor,
         lm_head_weight: torch.Tensor,
         active_draft_log_probs: Optional[torch.Tensor] = None,
+        target_norm_weight: Optional[torch.Tensor] = None,
+        target_norm_eps: float = 1e-6,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if active_hidden.numel() == 0:
             zero = active_weights.new_zeros(())
@@ -294,6 +297,17 @@ class DSparkTrainingModel(DFlashTrainingModel):
                 draft_probs = torch.softmax(draft_logits.float(), dim=-1)
             else:
                 draft_probs = active_draft_log_probs[start:end].exp()
+            if target_norm_weight is not None:
+                # ExampleHiddenStatesConnector exports the verifier's final
+                # hidden state before its final norm; re-apply it so the L1
+                # target matches the verifier's real sampling distribution.
+                normed = target_hidden_chunk.float()
+                normed = normed * torch.rsqrt(
+                    normed.pow(2).mean(dim=-1, keepdim=True) + target_norm_eps
+                )
+                target_hidden_chunk = (normed * target_norm_weight.float()).to(
+                    dtype=target_hidden_chunk.dtype
+                )
             target_logits = F.linear(target_hidden_chunk, lm_head_weight)
             target_probs = torch.softmax(target_logits.float(), dim=-1)
             l1_dist = (draft_probs - target_probs).abs().sum(dim=-1)
@@ -366,6 +380,8 @@ class DSparkTrainingModel(DFlashTrainingModel):
         loss_mask: torch.Tensor,
         lm_head_weight: torch.Tensor,
         target_last_hidden_states: Optional[torch.Tensor] = None,
+        target_norm_weight: Optional[torch.Tensor] = None,
+        target_norm_eps: float = 1e-6,
     ):
         bsz, seq_len = input_ids.shape
         device = input_ids.device
@@ -537,6 +553,8 @@ class DSparkTrainingModel(DFlashTrainingModel):
                         active_weights=active_loss_weights[l1_mask],
                         lm_head_weight=lm_head_weight,
                         active_draft_log_probs=reusable_draft_log_probs,
+                        target_norm_weight=target_norm_weight,
+                        target_norm_eps=target_norm_eps,
                     )
                 l1_loss = local_l1_sum / local_l1_den.clamp(min=1e-6)
             else:
@@ -714,6 +732,37 @@ class DSparkTrainerBackend(DFlashTrainerBackend):
             spec_model_path,
         )
 
+    def _build_target_final_norm(
+        self,
+        target_model_path: str,
+        *,
+        l1_loss_alpha: float,
+    ):
+        """Frozen verifier final RMSNorm applied to the DSpark L1 target.
+
+        Returns None only when the L1 loss is off (no distillation target
+        is computed in that case).
+        """
+        if l1_loss_alpha <= 0:
+            return None
+        target_final_norm = TargetFinalNorm.from_pretrained(target_model_path)
+        target_device = (
+            next(self.target_lm_head.parameters()).device
+            if self.target_lm_head is not None
+            else target_final_norm.weight.device
+        )
+        target_final_norm = target_final_norm.to(
+            device=target_device, dtype=torch.float32
+        ).eval()
+        for param in target_final_norm.parameters():
+            param.requires_grad_(False)
+        logger.info(
+            "[dspark-trainer] loaded frozen target final norm shape=%s eps=%s",
+            tuple(target_final_norm.weight.shape),
+            target_final_norm.eps,
+        )
+        return target_final_norm
+
     def _build_fallback_config(self, target_hf_config):
         training_cfg = self.config.rollout.drafter.training
         target_text_config = getattr(target_hf_config, "text_config", target_hf_config)
@@ -844,6 +893,16 @@ class DSparkTrainerBackend(DFlashTrainerBackend):
             target_model_path, target_hf_config
         )
         training_cfg = self.config.rollout.drafter.training
+        l1_loss_alpha = float(
+            training_cfg.get(
+                "dspark_l1_loss_alpha",
+                getattr(drafter_config, "l1_loss_alpha", 0.9),
+            )
+        )
+        self.target_final_norm = self._build_target_final_norm(
+            target_model_path,
+            l1_loss_alpha=l1_loss_alpha,
+        )
         return DSparkTrainingModel(
             draft_model=draft_model,
             block_size=int(
@@ -872,12 +931,7 @@ class DSparkTrainerBackend(DFlashTrainerBackend):
                     getattr(drafter_config, "ce_loss_alpha", 0.1),
                 )
             ),
-            l1_loss_alpha=float(
-                training_cfg.get(
-                    "dspark_l1_loss_alpha",
-                    getattr(drafter_config, "l1_loss_alpha", 0.9),
-                )
-            ),
+            l1_loss_alpha=l1_loss_alpha,
             confidence_head_alpha=float(
                 training_cfg.get("dspark_confidence_loss_alpha", 0.0)
             ),
@@ -994,12 +1048,23 @@ class DSparkTrainerBackend(DFlashTrainerBackend):
         per_layer_dim = hidden_states.shape[-1] // num_context_layers
         hidden_states_list = list(hidden_states.split(per_layer_dim, dim=-1))
 
+        target_final_norm = getattr(self, "target_final_norm", None)
         loss, accuracy, loss_pp, acc_pp, count_pp, diagnostics = model(
             input_ids=batch["input_ids"],
             hidden_states_list=hidden_states_list,
             loss_mask=batch["loss_mask"],
             lm_head_weight=self.target_lm_head.fc.weight,
             target_last_hidden_states=batch.get("target_last_hidden_states"),
+            target_norm_weight=(
+                target_final_norm.weight
+                if target_final_norm is not None
+                else None
+            ),
+            target_norm_eps=(
+                target_final_norm.eps
+                if target_final_norm is not None
+                else 1e-6
+            ),
         )
         local_num_tokens = diagnostics.get("ce_weighted_token_count")
         if not torch.is_tensor(local_num_tokens):

--- a/verl_speco/models/target/target_head.py
+++ b/verl_speco/models/target/target_head.py
@@ -42,12 +42,20 @@ def _load_checkpoint_tensor(model_path: str, key: str) -> torch.Tensor:
         ckpt_file = os.path.join(model_path, weight_map[key])
         if ckpt_file.endswith(".safetensors"):
             with safe_open(ckpt_file, framework="pt", device="cpu") as f:
+                if key not in f.keys():
+                    raise KeyError(
+                        f"Tensor {key!r} not found in {ckpt_file}"
+                    )
                 return f.get_tensor(key)
         return torch.load(ckpt_file, map_location="cpu", weights_only=True)[key]
 
     safetensors_path = os.path.join(model_path, "model.safetensors")
     if os.path.exists(safetensors_path):
         with safe_open(safetensors_path, framework="pt", device="cpu") as f:
+            if key not in f.keys():
+                raise KeyError(
+                    f"Tensor {key!r} not found in {safetensors_path}"
+                )
             return f.get_tensor(key)
 
     pytorch_path = os.path.join(model_path, "pytorch_model.bin")
@@ -57,6 +65,78 @@ def _load_checkpoint_tensor(model_path: str, key: str) -> torch.Tensor:
     raise FileNotFoundError(
         f"No index.json, model.safetensors or pytorch_model.bin found in {model_path}"
     )
+
+
+_GEMMA_STYLE_FINAL_NORM_PREFIXES = ("gemma", "qwen3_5")
+_FINAL_NORM_KEY_CANDIDATES = (
+    "model.norm.weight",
+    "model.language_model.norm.weight",
+    "norm.weight",
+)
+
+
+class TargetFinalNorm(nn.Module):
+    """Frozen final RMSNorm of the target model.
+
+    vLLM's ExampleHiddenStatesConnector exports the target's final hidden
+    state *before* its final norm, but the target's real sampling distribution
+    is softmax(lm_head(norm(h))). The DSpark L1 target must therefore re-apply
+    this norm to the collected final hidden states.
+
+    Gemma-style checkpoints parameterize the norm as x * (1 + w); the +1 is
+    folded into the loaded weight. Qwen3.5 text models follow this convention.
+    """
+
+    def __init__(self, weight: torch.Tensor, eps: float = 1e-6):
+        super().__init__()
+        if weight.dim() != 1:
+            raise ValueError(
+                "TargetFinalNorm weight must be rank-1, got "
+                f"shape={tuple(weight.shape)}"
+            )
+        self.eps = float(eps)
+        self.weight = nn.Parameter(
+            weight.detach().clone().float(), requires_grad=False
+        )
+
+    @classmethod
+    def from_pretrained(cls, model_path: str) -> "TargetFinalNorm":
+        if not os.path.exists(os.path.join(model_path, "config.json")):
+            model_path = snapshot_download(repo_id=model_path)
+        with open(
+            os.path.join(model_path, "config.json"), encoding="utf-8"
+        ) as f:
+            config = json.load(f)
+        text_config = config.get("text_config", config) or {}
+        eps = float(text_config.get("rms_norm_eps", config.get("rms_norm_eps", 1e-6)))
+        model_types = [
+            str(value).lower()
+            for value in (config.get("model_type"), text_config.get("model_type"))
+            if value
+        ]
+
+        weight = None
+        last_error: KeyError | None = None
+        for key in _FINAL_NORM_KEY_CANDIDATES:
+            try:
+                weight = _load_checkpoint_tensor(model_path, key)
+                break
+            except KeyError as exc:
+                last_error = exc
+        if weight is None:
+            raise KeyError(
+                f"Could not find the target final-norm weight in {model_path}; "
+                f"tried keys {_FINAL_NORM_KEY_CANDIDATES}. The DSpark L1 "
+                "target needs the verifier final norm to match the real "
+                "sampling distribution softmax(lm_head(norm(h)))."
+            ) from last_error
+
+        if any(
+            model_type.startswith(_GEMMA_STYLE_FINAL_NORM_PREFIXES)
+            for model_type in model_types
+        ):
+            weight = weight.float() + 1.0
+        return cls(weight, eps=eps)
 
 
 class TargetHead(nn.Module):


### PR DESCRIPTION
## Problem

  DSpark drafter training distills the drafter towards the verifier's token distribution with an L1 loss. The target probabilities were computed as:

```python
target_logits = F.linear(target_hidden, lm_head_weight)
```

But the collected `target_hidden` states come from vLLM's `ExampleHiddenStatesConnector`, which exports the verifier's final hidden state **before** its final RMSNorm. The verifier's real sampling distribution is `softmax(lm_head(rmsnorm(h, w)))`, so the L1 target was a systematically biased distribution (TV ≈ 0.145 measured on Qwen3-30B-A3B).

The failure mode is insidious: the loss is self-consistent, so training still converges and outputs stay correct — only the online acceptance rate is capped well below what the same budget achieves with a correct target.

## Fix

- New `TargetFinalNorm` (`verl_speco/models/target/target_head.py`): the verifier's frozen final RMSNorm loaded from the target checkpoint.
- key candidates `model.norm.weight` / `model.language_model.norm.weight` / `norm.weight`
- `eps` from `config.json` (`rms_norm_eps`, incl. nested `text_config`)
- gemma-style `x*(1+w)` parameterization folded to `w+1` at load time for `gemma*` / `qwen3_5*` model types
- fp32, rank-1, `requires_grad=False`
- `DSparkTrainerBackend._build_target_final_norm` builds it whenever `dspark_l1_loss_alpha > 0`; the training step passes `weight`/`eps` through to the L1 chunk, which now re-applies the norm before the lm_head: `h * rsqrt(mean(h²)+eps) * w → F.linear(·, lm_head)`.

No config flag — the norm is unconditional whenever the L1 loss is on. The legacy no-norm path is only reachable with `dspark_l1_loss_alpha=0` (L1 disabled entirely).

## Results (A/B validation)

Single-variable A/B on Qwen3-30B-A3B (single-sample overfit, 125 steps × batch 8 = 1000 learnings, greedy with pinned server- and request-side seeds, drafter deployed with vLLM speculative decoding, k=7):

  |                             | A (fix)     | B (bug)      |
  |-----------------------------|-------------|--------------|
  | Training accuracy / L1 loss | **0.993** / 0.019 | 0.988 / 0.041 |
  | Online acceptance rate      | **0.912**   | 0.619        |
  | Mean accepted len / block of 8 | 6.39     | 4.33         |
  | Draft rounds (3×256 tok)    | 39          | 54 (+38%)    |

- Outputs of both runs are token-identical to non-speculative decoding — the bug costs speed, not correctness.
- Offline ceiling check on the collected hidden states (no training): top-1 agreement 0.843 (raw) vs 0.987 (normed), bounding B's achievable acceptance at ≈0.855 on this sample.
- Per-position acceptance: pos-0 is identical between A and B (92–94%); the whole gap concentrates at deep in-block positions (conditional rates A ≈100% vs B 88%→78%), consistent with the biased target compounding through the drafter's in-block autoregressive rollout.

## Tests

- `tests/integration/test_target_final_norm.py` — `from_pretrained`: key candidates, nested `text_config` eps, folding (qwen3 / qwen3_5 / gemma3 parametrized), frozen weight, missing-weight `KeyError`.
- `tests/integration/test_dspark_trainer_backend.py` — L1 target numerics match a hand-computed reference with the norm applied; the norm provably changes the target (anti-vacuous assertion); kwargs plumbing is guarded so the norm cannot be silently dropped between `forward()` and the L1 computation.
- All 18 tests pass. `test_dspark_checkpoint_preserves_source_config...` fails identically on pristine `main` branch (pre-existing, non-blocking for this change).
