### PR TITLE
fix(dspark): skip inference-only drafter params on the online publish path

### DIFF
--- a/verl_speco/integration/vllm_runtime.py
+++ b/verl_speco/integration/vllm_runtime.py
@@ -1433,6 +1433,18 @@ patch_transformers_attention_layer_type_constants()
 install_verl_npu_vllm_import_compat()
 
 
+# vLLM's own Qwen3DSparkForCausalLM.load_weights() skips these
+# (``skip_substrs = ["mask_embedding", "confidence_head"]``): the confidence head
+# is not wired into inference, so the served Qwen3DSparkModel never registers it.
+# A trained DSpark drafter does carry those weights, and the online publish path
+# streams them straight into the inner model, which rejects the unknown module.
+_DSPARK_INFERENCE_ONLY_SKIPPED = ("confidence_head",)
+
+
+def _is_inference_only_skipped_dspark_param(name: str) -> bool:
+    return any(marker in name for marker in _DSPARK_INFERENCE_ONLY_SKIPPED)
+
+
 def _is_dspark_hf_config(hf_config: Any) -> bool:
     architectures = _get_nested(hf_config, ("architectures",), None) or []
     if isinstance(architectures, str):
@@ -3337,6 +3349,12 @@ class SpecoVLLMColocateWorkerExtension(_VLLMWorkerExtensionBase):
             translated_bucket = [
                 (translate_name(str(name)), tensor) for name, tensor in bucket_weights
             ]
+            if is_dspark:
+                translated_bucket = [
+                    (name, tensor)
+                    for name, tensor in translated_bucket
+                    if not _is_inference_only_skipped_dspark_param(name)
+                ]
             if not translated_bucket:
                 return
             bucket_count += 1


### PR DESCRIPTION
## Problem

`update_draft_weights_from_ipc()` streams every published DSpark tensor into the
inner `Qwen3DSparkModel`. vLLM's own `Qwen3DSparkForCausalLM.load_weights()`
carries `skip_substrs = ["mask_embedding", "confidence_head"]` because the
confidence head is not wired into inference — the served model never registers
it. A trained DSpark drafter *does* carry confidence-head weights, so the first
drafter refresh aborts the run:

```
ValueError: There is no module or parameter named 'confidence_head' in Qwen3DSparkModel.
The available parameters belonging to (Qwen3DSparkModel) are: {..., 'markov_head.markov_w1.weight',
'mask_embedding', 'markov_head.markov_w2.weight', 'fc.weight', 'hidden_norm.weight', ...}
```

This makes `speculative_algorithm=DSPARK` + `enable_drafter_training=True`
unusable on the GPU vLLM path: the run never completes a single publish cycle.

## Reproduction

- verl-SpeCo `7a16809` (current `main`, i.e. after #75), verl `release/v0.8.0`, vLLM `0.26.0`
- Qwen3-8B + [`deepseek-ai/dspark_qwen3_8b_block7`](https://huggingface.co/deepseek-ai/dspark_qwen3_8b_block7), 2×GPU, rollout TP=1
- GSM8K GRPO, `collect_interval_steps=5`, `training_interval_steps=5`, 8 steps

The run aborts at step 5 — the first publish. The MRV2 head patch added in #75
attaches `confidence_head` to the DFlash-based DSpark model, which does not
cover vLLM's native `Qwen3DSparkForCausalLM`, so that path is still affected.

## Fix

Filter the inference-only parameters before they enter `requested_names`, rather
than at load time, so `_speco_validate_loaded_draft_weights()` does not then
report them as a partial update.

## Verification

Same run, same commit, with the patch applied:

- 8/8 steps complete, no exception
- `SPECO committed online drafter revision=1 loaded_params=60` (60 weights in 5 buckets)
- `drafter/trained: 1.0`, `drafter/published: 1.0`
- rollout `mean_acceptance_length` steady at ~3.92–3.94 across the publish