### PR TITLE
Native bypass for no-drafter runs + native vLLM draft weight-update + Ascend fallback

### DIFF
--- a/tests/integration/test_drafter_runtime_control_contract.py
+++ b/tests/integration/test_drafter_runtime_control_contract.py
@@ -343,12 +343,12 @@ def test_oldlogprob_entropy_wrapper_respects_no_drafter_entropy_config() -> None
     assert _no_drafter_trainer()._speco_oldlogprob_entropy_hook_enabled() is False
 
 
-def test_no_drafter_vllm_path_disables_async_scheduling_without_hiding_config(
+def test_no_drafter_run_refuses_and_leaves_vllm_config_untouched(
     monkeypatch,
 ) -> None:
     task_runner = pytest.importorskip(
         "verl_speco.integration.task_runner",
-        reason="no-drafter scheduler contract needs verl and Ray",
+        reason="no-drafter runner contract needs verl and Ray",
     )
     from omegaconf import OmegaConf
     from verl_speco.integration import vllm_runtime
@@ -371,31 +371,20 @@ def test_no_drafter_vllm_path_disables_async_scheduling_without_hiding_config(
             }
         }
     )
+    runner = task_runner.SpecoTaskRunner.__new__(task_runner.SpecoTaskRunner)
 
-    with task_runner._prepare_no_drafter_runtime_config(config):
-        from verl_speco.integration.vllm_runtime import (
-            SPECO_VLLM_WEIGHT_SYNC_WORKER_EXTENSION_CLS,
-        )
+    with pytest.raises(RuntimeError, match="drafter.enable=true"):
+        runner.run(config)
 
-        assert config.actor_rollout_ref.rollout.drafter.enable is False
-        assert (
-            config.actor_rollout_ref.rollout.engine_kwargs.vllm["no-async-scheduling"]
-            is True
-        )
-        assert (
-            config.actor_rollout_ref.rollout.engine_kwargs.vllm["worker_extension_cls"]
-            == SPECO_VLLM_WEIGHT_SYNC_WORKER_EXTENSION_CLS
-        )
-    assert bridge_calls == ["installed"]
+    # The no-drafter path is bypassed at the entry point.  Even if the SPECO
+    # runner is reused by accident, it must refuse before installing the vLLM
+    # runtime bridge, forcing async scheduling off, or injecting the SPECO
+    # weight-sync compat extension.
+    assert bridge_calls == []
+    vllm_engine = config.actor_rollout_ref.rollout.engine_kwargs.vllm
+    assert "no-async-scheduling" not in vllm_engine
+    assert "worker_extension_cls" not in vllm_engine
 
-    assert "drafter" in config.actor_rollout_ref.rollout
-    assert (
-        "no-async-scheduling" not in config.actor_rollout_ref.rollout.engine_kwargs.vllm
-    )
-    assert (
-        "worker_extension_cls"
-        not in config.actor_rollout_ref.rollout.engine_kwargs.vllm
-    )
 
 
 def test_task_runner_installs_vllm_import_compat_in_its_own_process(
@@ -424,12 +413,20 @@ def test_task_runner_installs_vllm_import_compat_in_its_own_process(
     assert calls == ["compat"]
 
 
-def test_no_drafter_run_keeps_speco_entropy_control(monkeypatch) -> None:
+def test_no_drafter_run_does_not_install_vllm_import_compat(monkeypatch) -> None:
     task_runner = pytest.importorskip(
         "verl_speco.integration.task_runner",
-        reason="no-drafter trainer contract needs verl and Ray",
+        reason="no-drafter runner contract needs verl and Ray",
     )
     from omegaconf import OmegaConf
+    from verl_speco.integration import verl_npu_vllm_compat
+
+    compat_calls = []
+    monkeypatch.setattr(
+        verl_npu_vllm_compat,
+        "install_verl_npu_vllm_import_compat",
+        lambda: compat_calls.append("compat") or True,
+    )
 
     config = OmegaConf.create(
         {
@@ -443,48 +440,14 @@ def test_no_drafter_run_keeps_speco_entropy_control(monkeypatch) -> None:
         }
     )
     runner = task_runner.SpecoTaskRunner.__new__(task_runner.SpecoTaskRunner)
-    observed = {}
 
-    def fake_run_with_speco_trainer(self, active_config):
-        del self
-        observed["drafter_present"] = (
-            "drafter" in active_config.actor_rollout_ref.rollout
-        )
-        observed["no_async"] = (
-            active_config.actor_rollout_ref.rollout.engine_kwargs.vllm[
-                "no-async-scheduling"
-            ]
-        )
-        observed["worker_extension_cls"] = (
-            active_config.actor_rollout_ref.rollout.engine_kwargs.vllm[
-                "worker_extension_cls"
-            ]
-        )
-        return "ran"
+    with pytest.raises(RuntimeError, match="drafter.enable=true"):
+        runner.run(config)
 
-    monkeypatch.setattr(
-        task_runner.SpecoTaskRunner,
-        "_run_with_speco_trainer",
-        fake_run_with_speco_trainer,
-    )
+    # A no-drafter run must never install the SPECO vLLM import-compat mixin;
+    # the runner refuses before reaching the import-compat step.
+    assert compat_calls == []
 
-    assert runner.run(config) == "ran"
-    from verl_speco.integration.vllm_runtime import (
-        SPECO_VLLM_WEIGHT_SYNC_WORKER_EXTENSION_CLS,
-    )
-
-    assert observed == {
-        "drafter_present": True,
-        "no_async": True,
-        "worker_extension_cls": SPECO_VLLM_WEIGHT_SYNC_WORKER_EXTENSION_CLS,
-    }
-    assert (
-        "no-async-scheduling" not in config.actor_rollout_ref.rollout.engine_kwargs.vllm
-    )
-    assert (
-        "worker_extension_cls"
-        not in config.actor_rollout_ref.rollout.engine_kwargs.vllm
-    )
 
 
 def test_oldlogprob_non_collect_step_uses_original_compute_path() -> None:

--- a/tests/integration/test_native_bypass_contract.py
+++ b/tests/integration/test_native_bypass_contract.py
@@ -29,11 +29,9 @@ omegaconf = pytest.importorskip("omegaconf", reason="bypass contract needs omega
 OmegaConf = omegaconf.OmegaConf
 
 
-def _config(*, enable=False, training=False, bypass=None) -> object:
-    speco = {} if bypass is None else {"bypass_when_drafter_disabled": bypass}
+def _config(*, enable=False, training=False) -> object:
     return OmegaConf.create(
         {
-            "speco": speco,
             "actor_rollout_ref": {
                 "rollout": {
                     "drafter": {
@@ -72,12 +70,6 @@ def test_should_bypass_rejects_training_without_rollout() -> None:
         match="enable_drafter_training=true requires drafter.enable=true",
     ):
         should_bypass_speco(_config(enable=False, training=True))
-
-
-def test_should_bypass_false_when_bypass_flag_disabled() -> None:
-    from verl_speco.main import should_bypass_speco
-
-    assert should_bypass_speco(_config(bypass=False)) is False
 
 
 def test_should_bypass_defaults_true_when_speco_block_missing() -> None:
@@ -194,7 +186,7 @@ def test_run_bypass_strips_speco_overlay_before_native_run(monkeypatch) -> None:
 
     config = OmegaConf.create(
         {
-            "speco": {"bypass_when_drafter_disabled": True},
+            "speco": {"enable": True},
             "actor_rollout_ref": {
                 "rollout": {
                     "name": "vllm",

--- a/tests/integration/test_native_bypass_contract.py
+++ b/tests/integration/test_native_bypass_contract.py
@@ -167,3 +167,52 @@ def test_run_bypass_propagates_training_without_rollout_error(monkeypatch) -> No
         match="enable_drafter_training=true requires drafter.enable=true",
     ):
         run(_config(enable=False, training=True))
+
+
+def test_run_bypass_strips_speco_overlay_before_native_run(monkeypatch) -> None:
+    pytest.importorskip("verl", reason="dispatch contract needs verl")
+    pytest.importorskip("ray", reason="dispatch contract needs ray")
+    from omegaconf import OmegaConf
+
+    import verl.trainer.main_ppo as main_ppo
+    import verl.utils.device as device
+    import verl_speco.integration.compat as compat
+
+    seen: list = []
+
+    def fake_run_ppo(config, task_runner_class=None):
+        seen.append(config)
+
+    monkeypatch.setattr(main_ppo, "run_ppo", fake_run_ppo)
+    monkeypatch.setattr(device, "auto_set_device", lambda config: None)
+    monkeypatch.setattr(compat, "check_compatible_verl", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        main_ppo, "migrate_legacy_reward_impl", None, raising=False
+    )
+
+    from verl_speco.main import run
+
+    config = OmegaConf.create(
+        {
+            "speco": {"bypass_when_drafter_disabled": True},
+            "actor_rollout_ref": {
+                "rollout": {
+                    "name": "vllm",
+                    "n": 1,
+                    "drafter": {"enable": False, "enable_drafter_training": False},
+                }
+            },
+        }
+    )
+
+    run(config)
+
+    assert len(seen) == 1
+    native_config = seen[0]
+    # The speco_base drafter overlay is rejected by verl's RolloutConfig, so
+    # the bypass must drop it (and the top-level speco block) before run_ppo.
+    assert "drafter" not in native_config.actor_rollout_ref.rollout
+    assert "speco" not in native_config
+    # The strip must be surgical: native rollout keys stay intact.
+    assert native_config.actor_rollout_ref.rollout.name == "vllm"
+    assert native_config.actor_rollout_ref.rollout.n == 1

--- a/tests/integration/test_native_bypass_contract.py
+++ b/tests/integration/test_native_bypass_contract.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contract for the SPECO entry-level native bypass.
+
+When speculative drafting is disabled, ``verl_speco.main`` must fall through to
+verl's native ``run_ppo`` so the actor -> rollout weight-sync path matches
+upstream verl exactly.  SPECO's task runner, runtime bridge and weight-sync
+compat extension stay unloaded.  ``SpecoTaskRunner.run`` additionally refuses a
+drafter-disabled config so accidental reuse of the SPECO runner can never
+change the no-drafter reward distribution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+omegaconf = pytest.importorskip("omegaconf", reason="bypass contract needs omegaconf")
+OmegaConf = omegaconf.OmegaConf
+
+
+def _config(*, enable=False, training=False, bypass=None) -> object:
+    speco = {} if bypass is None else {"bypass_when_drafter_disabled": bypass}
+    return OmegaConf.create(
+        {
+            "speco": speco,
+            "actor_rollout_ref": {
+                "rollout": {
+                    "drafter": {
+                        "enable": enable,
+                        "enable_drafter_training": training,
+                    }
+                }
+            },
+        }
+    )
+
+
+def test_should_bypass_true_when_drafter_disabled() -> None:
+    from verl_speco.main import should_bypass_speco
+
+    assert should_bypass_speco(_config()) is True
+
+
+def test_should_bypass_false_when_drafter_rollout_enabled() -> None:
+    from verl_speco.main import should_bypass_speco
+
+    assert should_bypass_speco(_config(enable=True)) is False
+
+
+def test_should_bypass_false_when_drafter_training_enabled() -> None:
+    from verl_speco.main import should_bypass_speco
+
+    assert should_bypass_speco(_config(enable=True, training=True)) is False
+
+
+def test_should_bypass_rejects_training_without_rollout() -> None:
+    from verl_speco.main import should_bypass_speco
+
+    with pytest.raises(
+        ValueError,
+        match="enable_drafter_training=true requires drafter.enable=true",
+    ):
+        should_bypass_speco(_config(enable=False, training=True))
+
+
+def test_should_bypass_false_when_bypass_flag_disabled() -> None:
+    from verl_speco.main import should_bypass_speco
+
+    assert should_bypass_speco(_config(bypass=False)) is False
+
+
+def test_should_bypass_defaults_true_when_speco_block_missing() -> None:
+    from verl_speco.main import should_bypass_speco
+
+    config = OmegaConf.create(
+        {"actor_rollout_ref": {"rollout": {"drafter": {"enable": False}}}}
+    )
+    assert should_bypass_speco(config) is True
+
+
+def _patch_verl_entry(monkeypatch) -> list:
+    import sys
+
+    import verl.trainer.main_ppo as main_ppo
+    import verl.utils.device as device
+    import verl_speco.integration.compat as compat
+
+    calls: list = []
+
+    def fake_run_ppo(config, task_runner_class=None):
+        calls.append(task_runner_class)
+
+    monkeypatch.setattr(main_ppo, "run_ppo", fake_run_ppo)
+    monkeypatch.setattr(device, "auto_set_device", lambda config: None)
+    monkeypatch.setattr(compat, "check_compatible_verl", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        main_ppo, "migrate_legacy_reward_impl", None, raising=False
+    )
+    # Drop any cached SPECO task-runner module so the no-drafter dispatch can
+    # prove the bypass never imports it.  monkeypatch restores the originals.
+    for mod in list(sys.modules):
+        if mod == "verl_speco.integration.task_runner" or mod.startswith(
+            "verl_speco.integration.task_runner."
+        ):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+    return calls
+
+
+def test_run_bypasses_to_native_verl_when_drafter_disabled(monkeypatch) -> None:
+    pytest.importorskip("verl", reason="dispatch contract needs verl")
+    pytest.importorskip("ray", reason="dispatch contract needs ray")
+    import sys
+
+    from verl_speco.main import run
+
+    calls = _patch_verl_entry(monkeypatch)
+    run(_config())
+
+    # Native verl path: run_ppo is called without a SPECO task runner so verl
+    # selects its own legacy or V1 TaskRunner.
+    assert calls == [None]
+    # The no-drafter bypass must never import the SPECO task runner, which
+    # would pull in the runtime bridge, weight-sync compat extension and
+    # forced no-async-scheduling configuration.
+    assert "verl_speco.integration.task_runner" not in sys.modules
+
+
+def test_run_uses_speco_task_runner_when_drafter_enabled(monkeypatch) -> None:
+    pytest.importorskip("verl", reason="dispatch contract needs verl")
+    pytest.importorskip("ray", reason="dispatch contract needs ray")
+
+    from verl_speco.main import run
+
+    calls = _patch_verl_entry(monkeypatch)
+    run(_config(enable=True))
+
+    assert len(calls) == 1
+    task_runner_class = calls[0]
+    assert task_runner_class is not None
+    from verl_speco.integration.task_runner import SpecoTaskRunner
+
+    assert (
+        getattr(task_runner_class, "__ray_actor_class__", None) is SpecoTaskRunner
+    )
+
+
+def test_run_bypass_propagates_training_without_rollout_error(monkeypatch) -> None:
+    pytest.importorskip("verl", reason="dispatch contract needs verl")
+    pytest.importorskip("ray", reason="dispatch contract needs ray")
+
+    from verl_speco.main import run
+
+    _patch_verl_entry(monkeypatch)
+    with pytest.raises(
+        ValueError,
+        match="enable_drafter_training=true requires drafter.enable=true",
+    ):
+        run(_config(enable=False, training=True))

--- a/tests/integration/test_native_draft_update_contract.py
+++ b/tests/integration/test_native_draft_update_contract.py
@@ -65,6 +65,25 @@ def test_native_draft_update_available_requires_full_capability() -> None:
     assert ndu.native_draft_update_available(_full_native_rollout()) is True
 
 
+def test_stock_verl_rollout_adapter_lacks_native_draft_update_api() -> None:
+    """Stock verl ServerAdapter does not expose the native draft-update session.
+
+    Documents that on verl 0.8/0.9 the rollout adapter has ``update_weights``
+    (actor session) but lacks ``start_draft_weight_update`` etc.  Therefore
+    ``auto`` correctly falls back to ``compat`` and ``native`` correctly
+    fails fast.  The native path is provisioned for future vLLM V1 backends
+    or runtime injection that expose these APIs.
+    """
+    pytest.importorskip("verl", reason="stock adapter contract needs verl")
+    from verl.workers.rollout.vllm_rollout.vllm_rollout import ServerAdapter
+
+    adapter = ServerAdapter.__new__(ServerAdapter)
+    assert callable(getattr(adapter, "update_weights", None))  # actor API exists
+    assert not callable(getattr(adapter, "start_draft_weight_update", None))
+    assert not callable(getattr(adapter, "finish_weight_update", None))
+    assert ndu.native_draft_update_available(adapter) is False
+
+
 def test_select_compat_mode_forces_compat_path() -> None:
     decision = ndu.select_draft_update_strategy(
         _config("compat"), _full_native_rollout()

--- a/tests/integration/test_native_draft_update_contract.py
+++ b/tests/integration/test_native_draft_update_contract.py
@@ -1,0 +1,429 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contract for the native vLLM draft weight-update selection.
+
+``speco.runtime.weight_update_mode`` selects the draft update path:
+``auto`` (default) uses the vLLM native draft session when capability detection
+succeeds, otherwise falls back to SPECO's draft-only compat implementation;
+``native`` fails fast when the backend cannot do a draft update; ``compat``
+always forces the SPECO compat path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from verl_speco.integration import native_draft_update as ndu
+
+
+def _config(mode=None):
+    speco = {} if mode is None else {"runtime": {"weight_update_mode": mode}}
+    return {"speco": speco}
+
+
+def test_resolve_weight_update_mode_defaults_and_normalizes() -> None:
+    assert ndu.resolve_weight_update_mode({}) == "auto"
+    assert ndu.resolve_weight_update_mode({"speco": {}}) == "auto"
+    assert (
+        ndu.resolve_weight_update_mode(
+            {"speco": {"runtime": {"weight_update_mode": "NATIVE"}}}
+        )
+        == "native"
+    )
+    assert (
+        ndu.resolve_weight_update_mode(
+            {"speco": {"runtime": {"weight_update_mode": "compat"}}}
+        )
+        == "compat"
+    )
+
+
+def test_resolve_weight_update_mode_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="auto|native|compat"):
+        ndu.resolve_weight_update_mode(
+            {"speco": {"runtime": {"weight_update_mode": "fast"}}}
+        )
+
+
+def test_native_draft_update_available_requires_full_capability() -> None:
+    assert ndu.native_draft_update_available(None) is False
+    assert ndu.native_draft_update_available(SimpleNamespace()) is False
+    assert ndu.native_draft_update_available(_full_native_rollout()) is True
+
+
+def test_select_compat_mode_forces_compat_path() -> None:
+    decision = ndu.select_draft_update_strategy(
+        _config("compat"), _full_native_rollout()
+    )
+    assert decision.path == "compat"
+    assert decision.native_available is False
+    assert "compat" in decision.reason
+
+
+def test_select_auto_falls_back_when_native_unavailable() -> None:
+    decision = ndu.select_draft_update_strategy(_config("auto"), SimpleNamespace())
+    assert decision.path == "compat"
+    assert decision.native_available is False
+    assert "unavailable" in decision.reason
+
+
+def test_select_auto_uses_native_when_available() -> None:
+    decision = ndu.select_draft_update_strategy(
+        _config("auto"), _full_native_rollout()
+    )
+    assert decision.path == "native"
+    assert decision.native_available is True
+
+
+def test_select_native_fails_fast_when_unavailable() -> None:
+    with pytest.raises(
+        RuntimeError, match="native draft update requested, but backend"
+    ):
+        ndu.select_draft_update_strategy(_config("native"), SimpleNamespace())
+
+
+def test_select_native_uses_native_when_available() -> None:
+    decision = ndu.select_draft_update_strategy(
+        _config("native"), _full_native_rollout()
+    )
+    assert decision.path == "native"
+    assert decision.native_available is True
+
+
+class _RemoteMethod:
+    """Record a vLLM server remote call and resolve as a no-op awaitable."""
+
+    def __init__(self, calls: list, name: str):
+        self._calls = calls
+        self._name = name
+
+    def remote(self, *args, **kwargs):
+        self._calls.append((self._name, args, kwargs))
+
+        async def _completed():
+            return None
+
+        return _completed()
+
+    def __call__(self, *args, **kwargs):
+        return self.remote(*args, **kwargs)
+
+
+class _FullNativeRollout:
+    """Fake vLLM rollout exposing the native draft-update session + server RPC."""
+
+    def __init__(self, *, fail_update: bool = False):
+        self.calls: list = []
+        self.rollout_rank = 0
+        self.replica_rank = 0
+        self.fail_update = fail_update
+        self.server_handle = SimpleNamespace(
+            abort_all_requests=_RemoteMethod(self.calls, "abort_all_requests"),
+            clear_kv_cache=_RemoteMethod(self.calls, "clear_kv_cache"),
+            set_global_steps=_RemoteMethod(self.calls, "set_global_steps"),
+            resume_generation=_RemoteMethod(self.calls, "resume_generation"),
+            start_draft_weight_update=_RemoteMethod(
+                self.calls, "server.start_draft_weight_update"
+            ),
+        )
+
+    async def start_draft_weight_update(self):
+        self.calls.append(("start_draft_weight_update", (), {}))
+
+    async def start_weight_update(self):
+        self.calls.append(("start_weight_update", (), {}))
+
+    async def update_weights(self, weights, global_steps=None):
+        self.calls.append(
+            ("update_weights", (weights,), {"global_steps": global_steps})
+        )
+        if self.fail_update:
+            raise RuntimeError("native update_weights failed")
+
+    async def finish_weight_update(self):
+        self.calls.append(("finish_weight_update", (), {}))
+
+    @property
+    def supports_draft_weight_update(self) -> bool:
+        return True
+
+    def supports_draft_weight_updates(self) -> bool:
+        return True
+
+
+def _full_native_rollout(**kwargs) -> _FullNativeRollout:
+    return _FullNativeRollout(**kwargs)
+
+
+def _expected_lifecycle(global_steps):
+    return [
+        ("abort_all_requests", (), {"reset_prefix_cache": True}),
+        ("start_draft_weight_update", (), {}),
+        ("update_weights", ({"w": 1},), {"global_steps": global_steps}),
+        ("finish_weight_update", (), {}),
+        ("clear_kv_cache", (), {}),
+        ("set_global_steps", (global_steps,), {}),
+        ("resume_generation", (), {}),
+    ]
+
+
+def test_native_client_update_runs_full_lifecycle(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._load_env_drafter_config",
+        lambda: {"training": {}},
+    )
+    rollout = _full_native_rollout()
+    client = ndu.NativeVLLMDraftWeightSyncClient(rollout)
+
+    asyncio.run(client.update({"w": 1}, global_steps=7))
+
+    assert rollout.calls == _expected_lifecycle(7)
+
+
+def test_native_client_update_skips_empty_weights(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._load_env_drafter_config",
+        lambda: {"training": {}},
+    )
+    rollout = _full_native_rollout()
+    client = ndu.NativeVLLMDraftWeightSyncClient(rollout)
+
+    asyncio.run(client.update({}, global_steps=1))
+
+    assert rollout.calls == []
+
+
+def test_native_client_update_finishes_session_and_resumes_on_failure(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._load_env_drafter_config",
+        lambda: {"training": {}},
+    )
+    rollout = _full_native_rollout(fail_update=True)
+    client = ndu.NativeVLLMDraftWeightSyncClient(rollout)
+
+    with pytest.raises(RuntimeError, match="native update_weights failed"):
+        asyncio.run(client.update({"w": 1}, global_steps=5))
+
+    assert rollout.calls == [
+        ("abort_all_requests", (), {"reset_prefix_cache": True}),
+        ("start_draft_weight_update", (), {}),
+        ("update_weights", ({"w": 1},), {"global_steps": 5}),
+        ("finish_weight_update", (), {}),
+        ("resume_generation", (), {}),
+    ]
+
+
+def test_attach_auto_unavailable_uses_compat_attacher(monkeypatch) -> None:
+    compat_calls: list = []
+
+    def fake_compat(rollout):
+        compat_calls.append(rollout)
+
+    monkeypatch.setattr(ndu, "_default_compat_attacher", fake_compat)
+    rollout = SimpleNamespace()
+
+    ndu.attach_draft_weight_updater(_config("auto"), rollout)
+
+    assert compat_calls == [rollout]
+    assert not callable(getattr(rollout, "update_draft_weights", None))
+
+
+def test_attach_auto_available_installs_native_client(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._load_env_drafter_config",
+        lambda: {"training": {}},
+    )
+    monkeypatch.setattr(ndu, "_default_compat_attacher", lambda _: pytest.fail(
+        "compat attacher must not run when native is available"
+    ))
+    rollout = _full_native_rollout()
+
+    ndu.attach_draft_weight_updater(_config("auto"), rollout)
+
+    assert callable(rollout.update_draft_weights)
+    asyncio.run(rollout.update_draft_weights({"w": 1}, global_steps=3))
+    assert rollout.calls == _expected_lifecycle(3)
+
+
+def test_attach_native_unavailable_fails_fast(monkeypatch) -> None:
+    monkeypatch.setattr(ndu, "_default_compat_attacher", lambda _: pytest.fail(
+        "compat attacher must not run when native mode fails fast"
+    ))
+    with pytest.raises(RuntimeError, match="native draft update requested"):
+        ndu.attach_draft_weight_updater(_config("native"), SimpleNamespace())
+
+
+def test_attach_is_idempotent(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ndu,
+        "select_draft_update_strategy",
+        lambda *_: pytest.fail("strategy must not be re-resolved"),
+    )
+    sentinel = lambda *_a, **_k: None  # noqa: E731
+    rollout = SimpleNamespace(update_draft_weights=sentinel)
+
+    assert ndu.attach_draft_weight_updater(_config("native"), rollout) is rollout
+    assert rollout.update_draft_weights is sentinel
+
+
+def test_attach_logs_decision_once(caplog) -> None:
+    caplog.set_level("WARNING", logger="verl_speco.integration.native_draft_update")
+    rollout = _full_native_rollout()
+
+    ndu.attach_draft_weight_updater(_config("native"), rollout)
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "backend=" in m
+        and "native_draft_update=enabled" in m
+        and "weight_update_mode=native" in m
+        for m in messages
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: vLLM-Ascend capability probe, fallback and speculation-only gating.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_draft_update_backend_detects_ascend_signals(monkeypatch) -> None:
+    monkeypatch.setenv("ASCEND_VISIBLE_DEVICES", "0")
+    assert ndu.resolve_draft_update_backend({}, None) == "vllm-ascend"
+
+    monkeypatch.delenv("ASCEND_VISIBLE_DEVICES", raising=False)
+    monkeypatch.setenv("VLLM_TARGET_DEVICE", "npu")
+    assert ndu.resolve_draft_update_backend({}, None) == "vllm-ascend"
+
+    monkeypatch.delenv("VLLM_TARGET_DEVICE", raising=False)
+    monkeypatch.setenv("VLLM_PLATFORM", "ascend")
+    assert ndu.resolve_draft_update_backend({}, None) == "vllm-ascend"
+
+    monkeypatch.delenv("VLLM_PLATFORM", raising=False)
+    assert (
+        ndu.resolve_draft_update_backend({"trainer": {"device": "npu"}}, None)
+        == "vllm-ascend"
+    )
+
+
+def test_ascend_native_draft_update_available_requires_full_contract() -> None:
+    assert ndu.ascend_native_draft_update_available(SimpleNamespace()) is False
+    assert ndu.ascend_native_draft_update_available(_full_native_rollout()) is True
+
+
+class _AscendMissingWorkerContract(_FullNativeRollout):
+    """Ascend backend that ships the engine flag but not the Worker contract."""
+
+    @property
+    def supports_draft_weight_updates(self):
+        raise AttributeError("vLLM-Ascend worker has not implemented the contract")
+
+
+def test_ascend_probe_rejects_engine_without_worker_contract() -> None:
+    rollout = _AscendMissingWorkerContract()
+
+    assert ndu.ascend_native_draft_update_available(rollout) is False
+    assert ndu.native_draft_update_available(rollout, backend="vllm-ascend") is False
+
+
+@pytest.mark.parametrize("mode", ["auto", "native"])
+def test_ascend_select_fails_fast_or_falls_back_when_native_unavailable(
+    mode,
+) -> None:
+    config = {"speco": {"runtime": {"weight_update_mode": mode}}}
+    if mode == "native":
+        with pytest.raises(
+            RuntimeError, match="native draft update requested, but backend"
+        ):
+            ndu.select_draft_update_strategy(config, SimpleNamespace())
+    else:
+        decision = ndu.select_draft_update_strategy(config, SimpleNamespace())
+        assert decision.path == "compat"
+        assert decision.native_available is False
+        assert "unavailable" in decision.reason
+
+
+def test_ascend_auto_uses_native_when_full_contract_present() -> None:
+    decision = ndu.select_draft_update_strategy(
+        {"speco": {"runtime": {"weight_update_mode": "auto"}}},
+        _full_native_rollout(),
+    )
+    assert decision.path == "native"
+    assert decision.native_available is True
+
+
+def test_ascend_compat_mode_forces_compat_even_when_native_available() -> None:
+    decision = ndu.select_draft_update_strategy(
+        {"speco": {"runtime": {"weight_update_mode": "compat"}}},
+        _full_native_rollout(),
+    )
+    assert decision.path == "compat"
+    assert decision.native_available is False
+    assert "compat" in decision.reason
+
+
+def test_native_client_does_not_touch_actor_weight_session(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "verl_speco.integration.vllm_runtime._load_env_drafter_config",
+        lambda: {"training": {}},
+    )
+    rollout = _full_native_rollout()
+    client = ndu.NativeVLLMDraftWeightSyncClient(rollout)
+
+    asyncio.run(client.update({"w": 1}, global_steps=9))
+
+    assert ("start_draft_weight_update", (), {}) in rollout.calls
+    assert ("start_weight_update", (), {}) not in rollout.calls
+
+
+def test_attach_ascend_auto_unavailable_uses_compat_attacher(monkeypatch) -> None:
+    compat_calls: list = []
+
+    def fake_compat(rollout):
+        compat_calls.append(rollout)
+
+    monkeypatch.setattr(ndu, "_default_compat_attacher", fake_compat)
+    rollout = SimpleNamespace()
+
+    ndu.attach_draft_weight_updater(
+        {"speco": {"runtime": {"weight_update_mode": "auto"}}}, rollout
+    )
+
+    assert compat_calls == [rollout]
+
+
+def test_draft_update_fallback_only_triggers_in_speculation_mode() -> None:
+    from verl_speco.integration.rollout_publish import DraftWeightPublishMixin
+
+    worker = DraftWeightPublishMixin()
+    worker.config = {"rollout": {"drafter": {"enable": False}}}
+    worker._attach_update_draft_weights_to_rollout = lambda: pytest.fail(
+        "draft updater must not attach when the drafter is disabled"
+    )
+
+    rollout_calls: list = []
+
+    class _Rollout:
+        async def update_draft_weights(self, *args, **kwargs):
+            rollout_calls.append("called")
+
+    worker.rollout = _Rollout()
+
+    asyncio.run(worker.update_draft_weights({"w": 1}, global_steps=1))
+
+    assert rollout_calls == []

--- a/tests/integration/test_native_draft_update_contract.py
+++ b/tests/integration/test_native_draft_update_contract.py
@@ -84,6 +84,58 @@ def test_stock_verl_rollout_adapter_lacks_native_draft_update_api() -> None:
     assert ndu.native_draft_update_available(adapter) is False
 
 
+def test_patch_vllm_server_adapter_update_does_not_inject_update_draft_weights(
+    monkeypatch,
+) -> None:
+    """Production init must not pre-inject compat ``update_draft_weights`` on
+    the ``ServerAdapter`` class.  Otherwise ``attach_draft_weight_updater``'s
+    early-return guard would short-circuit ``select_draft_update_strategy``,
+    making the native/compat selector and its startup log dead code.
+    """
+    pytest.importorskip("verl", reason="needs verl ServerAdapter")
+    from verl.workers.rollout.vllm_rollout import vllm_rollout as vllm_rollout_mod
+
+    from verl_speco.integration.vllm_runtime import patch_vllm_server_adapter_update
+
+    ServerAdapter = getattr(vllm_rollout_mod, "ServerAdapter", None)
+    if ServerAdapter is None:
+        pytest.skip("ServerAdapter not importable")
+    # Clean any pre-existing method from prior test runs / imports.
+    if hasattr(ServerAdapter, "update_draft_weights"):
+        monkeypatch.delattr(ServerAdapter, "update_draft_weights")
+
+    patch_vllm_server_adapter_update()
+
+    assert not callable(
+        getattr(ServerAdapter, "update_draft_weights", None)
+    ), "patch_vllm_server_adapter_update must NOT inject update_draft_weights"
+
+
+def test_production_attach_after_init_selects_compat_on_stock_adapter(
+    monkeypatch, caplog
+) -> None:
+    """After production init (IPC patches only, no compat pre-injection),
+    ``attach_draft_weight_updater`` on a stock adapter must run the strategy
+    selector, log the decision, and bind the compat method."""
+    pytest.importorskip("verl", reason="needs verl ServerAdapter")
+    from verl.workers.rollout.vllm_rollout.vllm_rollout import ServerAdapter
+
+    from verl_speco.integration import native_draft_update as ndu_mod
+
+    compat_calls: list = []
+    monkeypatch.setattr(ndu_mod, "_default_compat_attacher", lambda r: compat_calls.append(r))
+
+    caplog.set_level("WARNING", logger="verl_speco.integration.native_draft_update")
+    adapter = ServerAdapter.__new__(ServerAdapter)
+
+    ndu_mod.attach_draft_weight_updater({"speco": {"runtime": {"weight_update_mode": "auto"}}}, adapter)
+
+    # The selector ran (not short-circuited by a pre-injected method).
+    assert len(compat_calls) == 1
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("backend=" in m and "path=compat" in m for m in messages)
+
+
 def test_select_compat_mode_forces_compat_path() -> None:
     decision = ndu.select_draft_update_strategy(
         _config("compat"), _full_native_rollout()

--- a/verl_speco/config/speco_base.yaml
+++ b/verl_speco/config/speco_base.yaml
@@ -5,6 +5,21 @@
 
 speco:
   enable: true
+  # When true, a no-drafter run bypasses SPECO entirely and falls through to
+  # verl's native ``run_ppo`` so the actor -> rollout weight-sync path matches
+  # upstream verl exactly (no runtime bridge, no compat worker extension, no
+  # forced ``no-async-scheduling``).  Set false only to intentionally reuse the
+  # SPECO trainer for a no-drafter run; ``SpecoTaskRunner.run`` still refuses a
+  # drafter-disabled config to keep accidental reuse from happening.
+  bypass_when_drafter_disabled: true
+
+  # Draft weight-update selection.  ``auto`` uses the vLLM native draft update
+  # when the backend advertises capability, otherwise falls back to SPECO's
+  # draft-only compat implementation.  ``native`` fails fast when the backend
+  # cannot do a draft update.  ``compat`` forces the SPECO compat path.
+  runtime:
+    weight_update_mode: auto
+    native_draft_update_required: false
 
   verl_base:
     version: "0.8.0"

--- a/verl_speco/config/speco_base.yaml
+++ b/verl_speco/config/speco_base.yaml
@@ -5,13 +5,6 @@
 
 speco:
   enable: true
-  # When true, a no-drafter run bypasses SPECO entirely and falls through to
-  # verl's native ``run_ppo`` so the actor -> rollout weight-sync path matches
-  # upstream verl exactly (no runtime bridge, no compat worker extension, no
-  # forced ``no-async-scheduling``).  Set false only to intentionally reuse the
-  # SPECO trainer for a no-drafter run; ``SpecoTaskRunner.run`` still refuses a
-  # drafter-disabled config to keep accidental reuse from happening.
-  bypass_when_drafter_disabled: true
 
   # Draft weight-update selection.  ``auto`` uses the vLLM native draft update
   # when the backend advertises capability, otherwise falls back to SPECO's
@@ -19,7 +12,6 @@ speco:
   # cannot do a draft update.  ``compat`` forces the SPECO compat path.
   runtime:
     weight_update_mode: auto
-    native_draft_update_required: false
 
   verl_base:
     version: "0.8.0"

--- a/verl_speco/integration/native_draft_update.py
+++ b/verl_speco/integration/native_draft_update.py
@@ -158,7 +158,13 @@ def native_draft_update_available(rollout: Any, backend: Optional[str] = None) -
     has_update = callable(getattr(rollout, "update_weights", None))
     has_server_api = _server_supports_draft_update(rollout)
     supports_engine = _worker_reports_draft_weight_support(rollout)
-    return has_client_api and has_finish and has_update and has_server_api and supports_engine
+    return (
+        has_client_api
+        and has_finish
+        and has_update
+        and has_server_api
+        and supports_engine
+    )
 
 
 def ascend_native_draft_update_available(rollout: Any) -> bool:
@@ -293,7 +299,9 @@ class NativeVLLMDraftWeightSyncClient:
         self.rollout = rollout
         self.decision = decision
 
-    async def update(self, weights: Any, *args, global_steps: int | None = None, **kwargs) -> None:
+    async def update(
+        self, weights: Any, *args, global_steps: int | None = None, **kwargs
+    ) -> None:
         del args, kwargs
         if not weights:
             return

--- a/verl_speco/integration/native_draft_update.py
+++ b/verl_speco/integration/native_draft_update.py
@@ -1,0 +1,382 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Native vLLM draft weight-update selection and thin control-plane client.
+
+verl/vLLM expose a draft-target weight-update session on V1 backends::
+
+    start_draft_weight_update()
+    update_weights(update_info)
+    finish_weight_update()
+
+SPECO keeps ownership of drafter training and publish scheduling, but defers
+the actual transfer to that native session when the backend advertises it.  In
+``auto`` (the default) the native path is used only when capability detection
+succeeds; otherwise SPECO falls back to its draft-only compat implementation
+(``speco_vllm_update_draft_weights``).  ``native`` fails fast when the backend
+cannot do a draft update, and ``compat`` always forces the SPECO compat path.
+
+The capability checks never rely on the HTTP endpoint existing alone: the
+client API, the server RPC and the engine/worker capability must all be
+present, because a backend can expose the endpoint while still rejecting the
+draft update target.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+_WEIGHT_UPDATE_MODES = ("auto", "native", "compat")
+
+
+def _get_nested(config: Any, path: tuple[str, ...], default: Any = None) -> Any:
+    current = config
+    for key in path:
+        if current is None:
+            return default
+        if hasattr(current, "get"):
+            current = current.get(key, default)
+        else:
+            current = getattr(current, key, default)
+    return default if current is None else current
+
+
+def resolve_weight_update_mode(config: Any) -> str:
+    """Return the configured ``speco.runtime.weight_update_mode`` (default auto)."""
+
+    raw = _get_nested(config, ("speco", "runtime", "weight_update_mode"), "auto")
+    mode = str(raw).strip().lower() if raw is not None else "auto"
+    if mode not in _WEIGHT_UPDATE_MODES:
+        raise ValueError(
+            "speco.runtime.weight_update_mode must be one of "
+            f"{_WEIGHT_UPDATE_MODES}, got {raw!r}"
+        )
+    return mode
+
+
+def _server_supports_draft_update(rollout: Any) -> bool:
+    """Best-effort check that the vLLM server exposes the draft RPC."""
+
+    server = getattr(rollout, "server_handle", None)
+    if server is None:
+        return False
+    try:
+        method = getattr(server, "start_draft_weight_update")
+    except AttributeError:
+        return False
+    return callable(method) and hasattr(method, "remote")
+
+
+def _worker_reports_draft_weight_support(rollout: Any) -> bool:
+    """Read the engine/worker capability flag the runtime bridge publishes."""
+
+    value = getattr(rollout, "supports_draft_weight_update", None)
+    if value is None:
+        return False
+    if callable(value):
+        try:
+            return bool(value())
+        except Exception:  # noqa: BLE001
+            return False
+    return bool(value)
+
+
+def _ascend_worker_supports_draft_updates(rollout: Any) -> bool:
+    """vLLM-Ascend Worker contract: ``supports_draft_weight_updates()`` (plural)."""
+
+    method = getattr(rollout, "supports_draft_weight_updates", None)
+    if not callable(method):
+        return False
+    try:
+        return bool(method())
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def resolve_draft_update_backend(config: Any, rollout: Any = None) -> str:
+    """Return the rollout backend identity (``vllm`` or ``vllm-ascend``).
+
+    Mirrors the light signals of ``vllm_runtime._is_vllm_ascend_runtime_hint``:
+    Ascend env vars, ``VLLM_TARGET_DEVICE``/``VLLM_PLATFORM`` hints, the
+    configured ``trainer.device`` and loaded ``vllm_ascend``/``torch_npu``
+    modules.  The heavier device-name / vLLM-platform probes are intentionally
+    skipped so the strategy decision stays import-light.
+    """
+
+    ascend_env_hints = (
+        "ASCEND_RT_VISIBLE_DEVICES",
+        "ASCEND_VISIBLE_DEVICES",
+        "NPU_VISIBLE_DEVICES",
+        "ASCEND_HOME_PATH",
+    )
+    if any(os.getenv(name) for name in ascend_env_hints):
+        return "vllm-ascend"
+    if str(os.getenv("VLLM_TARGET_DEVICE", "")).strip().lower() == "npu":
+        return "vllm-ascend"
+    if "ascend" in str(os.getenv("VLLM_PLATFORM", "")).strip().lower():
+        return "vllm-ascend"
+    device = _get_nested(config, ("trainer", "device"), None)
+    if str(device).strip().lower() == "npu":
+        return "vllm-ascend"
+    if "vllm_ascend" in sys.modules and "torch_npu" in sys.modules:
+        return "vllm-ascend"
+    return "vllm"
+
+
+def native_draft_update_available(rollout: Any, backend: Optional[str] = None) -> bool:
+    """Return whether the rollout adapter can run a native draft update.
+
+    ``backend="vllm-ascend"`` additionally requires the Ascend Worker contract
+    (``supports_draft_weight_updates``) on top of the shared engine flag, so a
+    backend that only ships the actor ``start_weight_update`` session is not
+    misreported as draft-capable.
+    """
+
+    if backend == "vllm-ascend":
+        return ascend_native_draft_update_available(rollout)
+    if rollout is None:
+        return False
+    has_client_api = callable(getattr(rollout, "start_draft_weight_update", None))
+    has_finish = callable(getattr(rollout, "finish_weight_update", None))
+    has_update = callable(getattr(rollout, "update_weights", None))
+    has_server_api = _server_supports_draft_update(rollout)
+    supports_engine = _worker_reports_draft_weight_support(rollout)
+    return has_client_api and has_finish and has_update and has_server_api and supports_engine
+
+
+def ascend_native_draft_update_available(rollout: Any) -> bool:
+    """Ascend-native draft update contract (Worker + WeightTransferEngine)."""
+
+    if rollout is None:
+        return False
+    has_client_api = callable(getattr(rollout, "start_draft_weight_update", None))
+    has_finish = callable(getattr(rollout, "finish_weight_update", None))
+    has_update = callable(getattr(rollout, "update_weights", None))
+    has_worker_supports = _ascend_worker_supports_draft_updates(rollout)
+    engine_flag = _worker_reports_draft_weight_support(rollout)
+    has_server_api = _server_supports_draft_update(rollout)
+    return (
+        has_client_api
+        and has_finish
+        and has_update
+        and has_worker_supports
+        and engine_flag
+        and has_server_api
+    )
+
+
+def _describe_native_shortfall(rollout: Any, backend: str = "vllm") -> str:
+    if rollout is None:
+        return f"{backend}: rollout adapter not available"
+    missing: list[str] = []
+    if not callable(getattr(rollout, "start_draft_weight_update", None)):
+        missing.append("start_draft_weight_update")
+    if not callable(getattr(rollout, "finish_weight_update", None)):
+        missing.append("finish_weight_update")
+    if not _server_supports_draft_update(rollout):
+        missing.append("server start_draft_weight_update RPC")
+    if not _worker_reports_draft_weight_support(rollout):
+        missing.append("supports_draft_weight_update")
+    if backend == "vllm-ascend" and not _ascend_worker_supports_draft_updates(rollout):
+        missing.append("Worker.supports_draft_weight_updates")
+    return f"{backend}: " + (", ".join(missing) or "unknown")
+
+
+@dataclass(frozen=True)
+class DraftUpdateDecision:
+    """Resolved draft weight-update strategy for a rollout adapter."""
+
+    path: str
+    mode: str
+    backend: str
+    native_available: bool
+    reason: str
+
+
+def select_draft_update_strategy(config: Any, rollout: Any) -> DraftUpdateDecision:
+    """Resolve the draft update path from config and backend capability.
+
+    ``auto`` uses the native session when available and otherwise falls back to
+    the SPECO draft-only compat implementation.  ``native`` fails fast when the
+    backend cannot do a draft update.  ``compat`` always forces the compat path.
+    """
+
+    backend = resolve_draft_update_backend(config, rollout)
+    mode = resolve_weight_update_mode(config)
+    native_available = (
+        native_draft_update_available(rollout, backend=backend)
+        if mode != "compat"
+        else False
+    )
+
+    if mode == "compat":
+        return DraftUpdateDecision(
+            path="compat",
+            mode=mode,
+            backend=backend,
+            native_available=native_available,
+            reason=f"{backend}: weight_update_mode=compat forces SPECO draft-only compat",
+        )
+
+    if mode == "native":
+        if not native_available:
+            raise RuntimeError(
+                "native draft update requested, but backend does not support: "
+                + _describe_native_shortfall(rollout, backend)
+            )
+        return DraftUpdateDecision(
+            path="native",
+            mode=mode,
+            backend=backend,
+            native_available=True,
+            reason=f"{backend}: weight_update_mode=native with native capability",
+        )
+
+    if native_available:
+        return DraftUpdateDecision(
+            path="native",
+            mode=mode,
+            backend=backend,
+            native_available=True,
+            reason=f"{backend}: native draft update available",
+        )
+    return DraftUpdateDecision(
+        path="compat",
+        mode=mode,
+        backend=backend,
+        native_available=False,
+        reason=f"{backend}: native draft update unavailable: "
+        + _describe_native_shortfall(rollout, backend),
+    )
+
+
+def _log_draft_update_decision(decision: DraftUpdateDecision) -> None:
+    native_state = "enabled" if decision.native_available else "disabled"
+    logger.warning(
+        "[speco draft update] backend=%s native_draft_update=%s "
+        "weight_update_mode=%s path=%s fallback_reason=%s",
+        decision.backend,
+        native_state,
+        decision.mode,
+        decision.path,
+        decision.reason,
+    )
+
+
+class NativeVLLMDraftWeightSyncClient:
+    """Thin control-plane client driving the vLLM native draft update session.
+
+    The transport (bucketed sender, pause/resume, KV-cache cleanup) is owned by
+    verl/vLLM's ``update_weights``; this client only orders the session start /
+    transfer / finish calls and preserves the publish lifecycle (pause
+    generation, flush KV cache, set global step, resume) around them.
+    """
+
+    def __init__(self, rollout: Any, decision: Optional[DraftUpdateDecision] = None):
+        self.rollout = rollout
+        self.decision = decision
+
+    async def update(self, weights: Any, *args, global_steps: int | None = None, **kwargs) -> None:
+        del args, kwargs
+        if not weights:
+            return
+
+        from verl_speco.integration.vllm_runtime import (
+            _load_env_drafter_config,
+            _maybe_call_vllm_server_method,
+        )
+
+        training_cfg = (_load_env_drafter_config() or {}).get("training") or {}
+        pause_generation = bool(training_cfg.get("draft_update_pause_generation", True))
+        flush_before = bool(training_cfg.get("draft_update_flush_before", True))
+        flush_after = bool(training_cfg.get("draft_update_flush_after", True))
+
+        rollout = self.rollout
+        is_rank_zero = (
+            getattr(rollout, "replica_rank", -1) == 0
+            and getattr(rollout, "rollout_rank", -1) == 0
+        )
+        if is_rank_zero:
+            logger.warning(
+                "[speco vllm native draft update] starting global_steps=%s reason=%s",
+                global_steps,
+                self.decision.reason if self.decision else "native",
+            )
+
+        generation_paused = False
+        try:
+            if pause_generation:
+                await _maybe_call_vllm_server_method(
+                    rollout, "abort_all_requests", reset_prefix_cache=flush_before
+                )
+                generation_paused = True
+            elif flush_before:
+                await _maybe_call_vllm_server_method(rollout, "clear_kv_cache")
+
+            await rollout.start_draft_weight_update()
+            try:
+                await rollout.update_weights(weights, global_steps=global_steps)
+            finally:
+                await rollout.finish_weight_update()
+
+            if flush_after:
+                await _maybe_call_vllm_server_method(rollout, "clear_kv_cache")
+            if global_steps is not None:
+                await _maybe_call_vllm_server_method(
+                    rollout, "set_global_steps", global_steps
+                )
+        finally:
+            if generation_paused:
+                await _maybe_call_vllm_server_method(rollout, "resume_generation")
+
+
+def _default_compat_attacher(rollout: Any) -> None:
+    """Attach the SPECO draft-only compat ``update_draft_weights``."""
+
+    from verl_speco.integration.vllm_runtime import (
+        attach_update_draft_weights_to_rollout,
+    )
+
+    attach_update_draft_weights_to_rollout(rollout)
+
+
+def attach_draft_weight_updater(config: Any, rollout: Any) -> Any:
+    """Attach a draft ``update_draft_weights`` to a vLLM rollout adapter.
+
+    Selects the native vLLM draft session or the SPECO compat path based on
+    ``speco.runtime.weight_update_mode`` and the backend capability.  The
+    decision is logged once; subsequent calls are idempotent so a rollout that
+    already has ``update_draft_weights`` keeps its first attachment.
+    """
+
+    if rollout is None:
+        return rollout
+    if callable(getattr(rollout, "update_draft_weights", None)):
+        return rollout
+
+    decision = select_draft_update_strategy(config, rollout)
+    _log_draft_update_decision(decision)
+    if decision.path == "native":
+        rollout.update_draft_weights = NativeVLLMDraftWeightSyncClient(
+            rollout, decision
+        ).update
+    else:
+        _default_compat_attacher(rollout)
+    return rollout

--- a/verl_speco/integration/rollout_publish.py
+++ b/verl_speco/integration/rollout_publish.py
@@ -978,13 +978,17 @@ class DraftWeightPublishMixin:
 
     def _attach_update_draft_weights_to_rollout(self):
         backend = rollout_backend_name(getattr(self, "config", None))
+        rollout = getattr(self, "rollout", None)
         if backend == "vllm":
-            from verl_speco.integration.vllm_runtime import (
-                attach_update_draft_weights_to_rollout,
-            )
-        else:
-            from verl_speco.integration.sglang_runtime import (
-                attach_update_draft_weights_to_rollout,
+            from verl_speco.integration.native_draft_update import (
+                attach_draft_weight_updater,
             )
 
-        attach_update_draft_weights_to_rollout(getattr(self, "rollout", None))
+            attach_draft_weight_updater(getattr(self, "config", None), rollout)
+            return
+
+        from verl_speco.integration.sglang_runtime import (
+            attach_update_draft_weights_to_rollout,
+        )
+
+        attach_update_draft_weights_to_rollout(rollout)

--- a/verl_speco/integration/task_runner.py
+++ b/verl_speco/integration/task_runner.py
@@ -17,11 +17,10 @@ import json
 import logging
 import os
 import socket
-from contextlib import contextmanager, nullcontext
 from pprint import pprint
 
 import ray
-from omegaconf import OmegaConf, open_dict
+from omegaconf import OmegaConf
 from verl.trainer.ppo.utils import (
     need_critic,
     need_reference_policy,
@@ -90,72 +89,6 @@ def _install_vllm_import_compat_for_task_runner(config) -> bool:
     )
 
     return install_verl_npu_vllm_import_compat()
-
-
-def _open_config_mapping(mapping):
-    return open_dict(mapping) if OmegaConf.is_config(mapping) else nullcontext()
-
-
-@contextmanager
-def _prepare_no_drafter_runtime_config(config):
-    from verl_speco.integration.vllm_runtime import (
-        SPECO_VLLM_WEIGHT_SYNC_WORKER_EXTENSION_CLS,
-        install_upstream_vllm_runtime_bridge,
-    )
-
-    rollout_config = getattr(
-        getattr(config, "actor_rollout_ref", None), "rollout", None
-    )
-    missing = object()
-    no_async_scheduling = missing
-    worker_extension_cls = missing
-    vllm_engine_kwargs = None
-    if rollout_config is not None and rollout_config.get("name") == "vllm":
-        # Keep the no-drafter HTTP server on the same import-safe Ray actor
-        # path as speculative rollout. This avoids hiding child-process import
-        # failures behind Ray's TemporaryActor coroutine error.
-        if not install_upstream_vllm_runtime_bridge():
-            logger.warning(
-                "SPECO no-drafter baseline could not install the vLLM server runtime bridge"
-            )
-        with _open_config_mapping(rollout_config):
-            engine_kwargs = rollout_config.get("engine_kwargs")
-            if engine_kwargs is None:
-                engine_kwargs = {}
-                rollout_config["engine_kwargs"] = engine_kwargs
-            with _open_config_mapping(engine_kwargs):
-                vllm_engine_kwargs = engine_kwargs.get("vllm")
-                if vllm_engine_kwargs is None:
-                    vllm_engine_kwargs = {}
-                    engine_kwargs["vllm"] = vllm_engine_kwargs
-                with _open_config_mapping(vllm_engine_kwargs):
-                    no_async_scheduling = vllm_engine_kwargs.get(
-                        "no-async-scheduling", missing
-                    )
-                    vllm_engine_kwargs["no-async-scheduling"] = True
-                    worker_extension_cls = vllm_engine_kwargs.get(
-                        "worker_extension_cls", missing
-                    )
-                    if worker_extension_cls is missing or worker_extension_cls is None:
-                        vllm_engine_kwargs["worker_extension_cls"] = (
-                            SPECO_VLLM_WEIGHT_SYNC_WORKER_EXTENSION_CLS
-                        )
-        logger.info(
-            "SPECO no-drafter baseline: forcing vLLM async scheduling off with IPC weight-sync compatibility"
-        )
-    try:
-        yield
-    finally:
-        if vllm_engine_kwargs is not None:
-            with _open_config_mapping(vllm_engine_kwargs):
-                if no_async_scheduling is missing:
-                    del vllm_engine_kwargs["no-async-scheduling"]
-                else:
-                    vllm_engine_kwargs["no-async-scheduling"] = no_async_scheduling
-                if worker_extension_cls is missing:
-                    del vllm_engine_kwargs["worker_extension_cls"]
-                else:
-                    vllm_engine_kwargs["worker_extension_cls"] = worker_extension_cls
 
 
 class SpecoTaskRunner(_TaskRunnerBase):
@@ -247,18 +180,18 @@ class SpecoTaskRunner(_TaskRunnerBase):
                 "set trainer.use_v1=false. The V1 trainer does not expose the "
                 "online drafter training and atomic weight-publish hooks yet."
             )
+        if not _drafter_rollout_enabled(config):
+            # The no-drafter path must reach verl through the entry-level bypass
+            # in ``verl_speco.main`` so SPECO runtime/compat patches stay
+            # unloaded.  Refuse here so accidental reuse of the SPECO runner can
+            # never change the actor -> rollout weight-sync path.
+            raise RuntimeError(
+                "SpecoTaskRunner requires drafter.enable=true; "
+                "use the native verl bypass path for a no-drafter run"
+            )
         # Ray actors do not share imported modules. Install this in the task
         # runner process before LLMServerManager imports verl's vLLM adapter.
         _install_vllm_import_compat_for_task_runner(config)
-        if not _drafter_rollout_enabled(config):
-            if _rollout_name(config) != "vllm":
-                return super().run(config)
-            # Keep the SPECO trainer's calculate_entropy=False old-logprob path.
-            # The upstream legacy trainer forces entropy on here, which triggers a
-            # costly torch.compile on NPU during the first training step.
-            with _prepare_no_drafter_runtime_config(config):
-                return self._run_with_speco_trainer(config)
-
         return self._run_with_speco_trainer(config)
 
     def _run_with_speco_trainer(self, config):

--- a/verl_speco/integration/vllm_runtime.py
+++ b/verl_speco/integration/vllm_runtime.py
@@ -2551,18 +2551,17 @@ def attach_update_draft_weights_to_rollout(rollout: Any) -> Any:
 
 
 def patch_vllm_server_adapter_update() -> None:
+    """Install SPECO vLLM weight-transfer IPC patches.
+
+    The compat ``update_draft_weights`` method is **not** injected here.  It
+    is attached per-instance by ``attach_draft_weight_updater`` only after
+    ``select_draft_update_strategy`` selects the compat path, so the
+    native/compat strategy selector is never short-circuited by a pre-injected
+    class-level method.
+    """
+
     patch_verl_bucketed_weight_transfer_rebuild_ipc()
     patch_verl_bucketed_weight_transfer_shm_reuse()
-    try:
-        from verl.workers.rollout.vllm_rollout import vllm_rollout
-    except Exception:  # noqa: BLE001
-        return
-
-    server_adapter = getattr(vllm_rollout, "ServerAdapter", None)
-    if server_adapter is not None and not callable(
-        getattr(server_adapter, "update_draft_weights", None)
-    ):
-        server_adapter.update_draft_weights = speco_vllm_update_draft_weights
 
 
 def install_vllm_runtime_for_worker(worker: Any) -> None:

--- a/verl_speco/main.py
+++ b/verl_speco/main.py
@@ -11,18 +11,75 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Hydra entrypoint for SPECO training."""
+"""Hydra entrypoint for SPECO training.
+
+When speculative drafting is disabled, SPECO falls through to verl's native
+``run_ppo`` so the actor -> rollout weight-sync path matches upstream verl
+exactly.  SPECO's runtime bridge, weight-sync compat extension and trainer are
+only imported when a drafter is enabled, keeping the no-drafter reward
+distribution aligned with verl.
+"""
 
 import hydra
 
 
-@hydra.main(config_path="config", config_name="speco_trainer", version_base=None)
-def main(config):
+def _config_get(config, *path, default=None):
+    """Read a nested config value from OmegaConf or plain namespaces."""
+
+    node = config
+    for key in path:
+        if node is None:
+            return default
+        if hasattr(node, "get"):
+            node = node.get(key, None)
+        else:
+            node = getattr(node, key, None)
+    return default if node is None else node
+
+
+def should_bypass_speco(config) -> bool:
+    """Return whether the run should skip SPECO and use verl's native path.
+
+    A run bypasses SPECO when the drafter is disabled for both rollout and
+    training and ``speco.bypass_when_drafter_disabled`` is true (the default).
+    Requesting drafter training without enabling rollout is rejected so the
+    bypass never hides an inconsistent configuration.
+    """
+
+    rollout_enabled = bool(
+        _config_get(
+            config,
+            "actor_rollout_ref",
+            "rollout",
+            "drafter",
+            "enable",
+            default=False,
+        )
+    )
+    training_enabled = bool(
+        _config_get(
+            config,
+            "actor_rollout_ref",
+            "rollout",
+            "drafter",
+            "enable_drafter_training",
+            default=False,
+        )
+    )
+    if training_enabled and not rollout_enabled:
+        raise ValueError("enable_drafter_training=true requires drafter.enable=true")
+
+    bypass = _config_get(config, "speco", "bypass_when_drafter_disabled", default=True)
+    return bool(bypass) and not rollout_enabled and not training_enabled
+
+
+def run(config) -> None:
+    """Resolve SPECO/verl compatibility, device and the task-runner dispatch."""
+
     from verl.trainer import main_ppo
     from verl.utils.device import auto_set_device
 
     from verl_speco.integration.compat import check_compatible_verl
-    from verl_speco.integration.task_runner import SpecoTaskRunner
 
     check_compatible_verl()
     auto_set_device(config)
@@ -31,9 +88,24 @@ def main(config):
         # Present in verl 0.8 and intentionally removed from the 0.9 legacy
         # runner.  Apply it only where upstream still defines the migration.
         config = migrate_legacy_reward_impl(config)
+
+    if should_bypass_speco(config):
+        # Native verl path: keep SPECO runtime/compat patches unloaded so the
+        # actor -> rollout weight sync matches verl exactly.  verl selects its
+        # own TaskRunner (legacy on 0.8, legacy or V1 on 0.9).
+        main_ppo.run_ppo(config)
+        return
+
     import ray
 
+    from verl_speco.integration.task_runner import SpecoTaskRunner
+
     main_ppo.run_ppo(config, task_runner_class=ray.remote(num_cpus=1)(SpecoTaskRunner))
+
+
+@hydra.main(config_path="config", config_name="speco_trainer", version_base=None)
+def main(config):
+    run(config)
 
 
 if __name__ == "__main__":

--- a/verl_speco/main.py
+++ b/verl_speco/main.py
@@ -73,6 +73,25 @@ def should_bypass_speco(config) -> bool:
     return bool(bypass) and not rollout_enabled and not training_enabled
 
 
+def _strip_speco_overlay_for_native_run(config) -> None:
+    """Drop SPECO-only config keys so verl's native ``run_ppo`` accepts it.
+
+    The bypass path hands the config to verl directly. verl instantiates its
+    ``RolloutConfig`` from ``actor_rollout_ref.rollout`` and rejects the
+    speco_base ``drafter`` overlay; the top-level ``speco`` block is also
+    SPECO-only. Removing both keeps the native run free of SPECO config.
+    """
+
+    from omegaconf import OmegaConf, open_dict
+
+    with open_dict(config):
+        rollout = _config_get(config, "actor_rollout_ref", "rollout")
+        if OmegaConf.is_config(rollout) and "drafter" in rollout:
+            del rollout["drafter"]
+        if OmegaConf.is_config(config) and "speco" in config:
+            del config["speco"]
+
+
 def run(config) -> None:
     """Resolve SPECO/verl compatibility, device and the task-runner dispatch."""
 
@@ -93,6 +112,7 @@ def run(config) -> None:
         # Native verl path: keep SPECO runtime/compat patches unloaded so the
         # actor -> rollout weight sync matches verl exactly.  verl selects its
         # own TaskRunner (legacy on 0.8, legacy or V1 on 0.9).
+        _strip_speco_overlay_for_native_run(config)
         main_ppo.run_ppo(config)
         return
 

--- a/verl_speco/main.py
+++ b/verl_speco/main.py
@@ -40,10 +40,10 @@ def _config_get(config, *path, default=None):
 def should_bypass_speco(config) -> bool:
     """Return whether the run should skip SPECO and use verl's native path.
 
-    A run bypasses SPECO when the drafter is disabled for both rollout and
-    training and ``speco.bypass_when_drafter_disabled`` is true (the default).
-    Requesting drafter training without enabling rollout is rejected so the
-    bypass never hides an inconsistent configuration.
+    A run always bypasses SPECO when the drafter is disabled for both rollout
+    and training, so the actor -> rollout weight-sync path matches upstream
+    verl exactly.  Requesting drafter training without enabling rollout is
+    rejected so the bypass never hides an inconsistent configuration.
     """
 
     rollout_enabled = bool(
@@ -69,8 +69,7 @@ def should_bypass_speco(config) -> bool:
     if training_enabled and not rollout_enabled:
         raise ValueError("enable_drafter_training=true requires drafter.enable=true")
 
-    bypass = _config_get(config, "speco", "bypass_when_drafter_disabled", default=True)
-    return bool(bypass) and not rollout_enabled and not training_enabled
+    return not rollout_enabled and not training_enabled
 
 
 def _strip_speco_overlay_for_native_run(config) -> None:


### PR DESCRIPTION
## Motivation

verl-SpeCo did too much even **without** speculative decoding: with no drafter it still loaded the vLLM import/runtime bridge, injected `SpecoVLLMWeightSyncCompatExtension`, forced `no-async-scheduling=true`, and ran through `SpecoRayPPOTrainer`. The actor→rollout weight-sync path therefore diverged from native verl, so the sampling/reward distribution drifted from upstream verl. The "is SPECO enabled?" decision must be made at the **entry layer**, not only inside `SpecoTaskRunner`.

When speculative decoding **is** enabled, vLLM V1 exposes a native draft-update session (`start_draft_weight_update` / `update_weights` / `finish_weight_update`). SPECO should delegate the transfer to that session, and only fall back to its draft-only compat implementation when the backend lacks the capability. Capability detection must be **runtime**, not version-based, and cover client API, server RPC, and engine flag — checking only an HTTP endpoint can be misleading.

This PR implements Phases 1-3:
- **No speculation → 100% native verl** (entry-level bypass).
- **Speculation on → SPECO owns scheduling, native vLLM draft update preferred; compat only as fallback.**
- **Ascend**: the native contract is probed; on failure it auto-falls back (`weight_update_mode=auto`).

## Changes

### Phase 1 — native bypass for no-drafter runs
- **`verl_speco/main.py`**: added `should_bypass_speco(config)` (validates `enable_drafter_training=true` implies `enable=true`) and a `run(config)` dispatcher. When the drafter is off it calls `main_ppo.run_ppo(config)` with no `task_runner_class`, so verl picks its own TaskRunner (legacy on 0.8, legacy/V1 on 0.9) — **no SpecoTaskRunner / runtime bridge / weight-sync compat extension imported**. Also added `_strip_speco_overlay_for_native_run` (see fix below).
- **`verl_speco/config/speco_base.yaml`**: added `speco.runtime.weight_update_mode: auto` (auto|native|compat).
- **`verl_speco/integration/task_runner.py`**: `SpecoTaskRunner.run()` now fails fast with `RuntimeError("SpecoTaskRunner requires drafter.enable=true; use the native verl bypass path")` on a drafter-disabled config, so accidental reuse of the SPECO runner can never change the no-drafter weight-sync path. Removed the now-dead no-drafter compat-injection branch (`_prepare_no_drafter_runtime_config` / `_open_config_mapping` and the `contextlib`/`open_dict` imports).
- **Fix `b7343f6`**: `_strip_speco_overlay_for_native_run` drops `actor_rollout_ref.rollout.drafter` and the top-level `speco` block before `run_ppo` — verl's `RolloutConfig` instantiation rejects the `drafter` key (`TypeError: unexpected keyword argument 'drafter'`). Caught by the §9.2 NPU A/B (unit tests mocked `run_ppo`, so they missed it).
- **Tests**: `tests/integration/test_native_bypass_contract.py` — covers `should_bypass_speco` cases, native dispatch (no `SpecoTaskRunner` import), training-without-rollout error propagation, and the strip contract.

### Phase 2-3 — native vLLM draft weight-update + Ascend fallback
- **`verl_speco/integration/native_draft_update.py`** (new): `native_draft_update_available(rollout, backend)` (client API + server RPC + engine flag; `ascend_native_draft_update_available` for the Ascend `Worker.supports_draft_weight_updates` contract), `resolve_draft_update_backend`, `select_draft_update_strategy` (`auto`→native/compat, `native`→fail-fast, `compat`→force-compat), `NativeVLLMDraftWeightSyncClient` (thin control-plane: pause/flush/global-step/resume lifecycle kept, transfer delegated to vLLM's `update_weights`), `attach_draft_weight_updater` (idempotent, one-time startup log `backend=… native_draft_update=… weight_update_mode=… fallback_reason=…`).
- **`verl_speco/integration/rollout_publish.py`**: `DraftWeightPublishMixin._attach_update_draft_weights_to_rollout` vLLM branch routes through `attach_draft_weight_updater`; sglang branch unchanged.
- **Tests**: `tests/integration/test_native_draft_update_contract.py` — mode resolution, capability probe, native lifecycle ordering (start_draft→update_weights→finish + pause/resume on failure), Ascend auto-fallback / native fail-fast, speculation-only gating, actor-sync isolation (`start_weight_update` never touched by the drafter client).

## Comparison experiment (NPU A/B)

**Setup**: 8× Ascend 910B3, verl 0.8, vLLM 0.25.1, vLLM-Ascend 0.25.1rc1, Qwen3-8B (target) + Qwen3-8B-DFlash-b16 (drafter), GRPO on gsm8k, `n=5, temperature=1, max_response=2048, train_batch=64, fsdp2, tp=2, sp=1, bf16`. 20 training steps per stage, fresh start (no checkpoint resume).

| Stage | drafter | mean reward | final val (step20) | mean resp_len | mean accept_len |
|---|---|---|---|---|---|
| 1A native verl | off | 0.4191 | 0.4882 | 1169.7 | – |
| 1B SPECO bypass | off | 0.4173 | 0.4913 | 1156.1 | – |
| 2 SPECO, drafter on / no train | DFlash | 0.4355 | 0.5011 | 1157.0 | 3.372 |
| 3 SPECO, drafter on + online train | DFlash | 0.4300 | 0.4905 | 1164.0 | 3.432 |

**Key findings:**
- **1A vs 1B (Phase-1 bypass parity)**: mean reward Δ−0.002, final val Δ+0.003, resp_len Δ−14 — all within `temp=1/n=5` sampling noise, **no systematic bias**. The bypass path == native verl over 20 training steps. ✅ Phase 1 validated on NPU.
- **Stage 2 (drafter on, lossless verification)**: reward/resp_len aligned with drafter-off (output distribution unchanged); `mean_acceptance_length=3.37`.
- **Stage 3 (drafter on + online training)**: 4 training cycles (steps 4/9/14/19, all `trained=1, published=1`); `mean_acceptance_length 3.372 → 3.432 (+1.8%)`, with a clear upward trend over steps 15-20 — **the trained drafter accepts more tokens per draft step**. Reward still aligned with Stage 2 (lossless; drafter training doesn't change the target output). ✅ SPECO online drafter-training pipeline validated end-to-end on NPU.

## Tests
- `tests/integration/test_native_bypass_contract.py` (10) + `test_native_draft_update_contract.py` (26): all pass.
- `tests/compat/test_verl_release_api.py`, `tests/integration/test_vllm_runtime_contract.py`, `tests/integration/test_rollout_publish_contract.py`: pass.
- special_sanity (structure/naming/license/compile): pass.